### PR TITLE
Handle different LED color orders, simplify LED glasses use

### DIFF
--- a/Adafruit_IS31FL3741.cpp
+++ b/Adafruit_IS31FL3741.cpp
@@ -622,46 +622,22 @@ void Adafruit_IS31FL3741_QT::drawPixel(int16_t x, int16_t y, uint16_t color) {
     Serial.print(") -> 0x");
     */
 
-    uint8_t col = x;
-    uint8_t row = y;
-
-    // remap the row
+    // Remap the row (y)
     static const uint8_t rowmap[] = {8, 5, 4, 3, 2, 1, 0, 7, 6};
-    row = rowmap[y];
+    y = rowmap[y];
 
-    uint16_t offset = 0;
-
-    if (row <= 5) {
-      if (col < 10) {
-        offset = 0x1E * row + col * 3;
-      } else {
-        offset = 0xB4 + 0x5A + 9 * row + (col - 10) * 3;
-      }
-    } else {
-      if (col < 10) {
-        offset = 0xB4 + (row - 6) * 0x1E + col * 3;
-      } else {
-        offset = 0xB4 + 0x5A + 9 * row + (col - 10) * 3;
-      }
-    }
-
-    // TO DO: incorporate RGB order here
-    int8_t r_off, g_off, b_off;
-    if ((col == 12) || (col % 2 == 1)) { // odds + last col
-      r_off = 1;
-      g_off = 0;
-      b_off = 2;
-    } else { // evens;
-      r_off = 2;
-      g_off = 1;
-      b_off = 0;
-    }
-
+    uint16_t offset = (x + ((x < 10) ? (y * 10) : (80 + y * 3))) * 3;
     // Serial.println(offset, HEX);
 
-    setLEDPWM(offset + r_off, r);
-    setLEDPWM(offset + g_off, g);
-    setLEDPWM(offset + b_off, b);
+    if ((x & 1) || (x == 12)) {       // Odd columns + last column
+      setLEDPWM(offset + rOffset, b); // Flip color order vs constructor
+      setLEDPWM(offset + gOffset, r);
+      setLEDPWM(offset + bOffset, g);
+    } else {                          // Even columns
+      setLEDPWM(offset + rOffset, r); // Color order follows constructor
+      setLEDPWM(offset + gOffset, g);
+      setLEDPWM(offset + bOffset, b);
+    }
   }
 }
 
@@ -688,48 +664,23 @@ void Adafruit_IS31FL3741_QT_buffered::drawPixel(int16_t x, int16_t y,
     Serial.print(") -> 0x");
     */
 
-    uint8_t col = x;
-    uint8_t row = y;
-
-    // remap the row
+    // Remap the row (y)
     static const uint8_t rowmap[] = {8, 5, 4, 3, 2, 1, 0, 7, 6};
-    row = rowmap[y];
+    y = rowmap[y];
 
-    uint16_t offset = 0;
-
-    if (row <= 5) {
-      if (col < 10) {
-        offset = 0x1E * row + col * 3;
-      } else {
-        offset = 0xB4 + 0x5A + 9 * row + (col - 10) * 3;
-      }
-    } else {
-      if (col < 10) {
-        offset = 0xB4 + (row - 6) * 0x1E + col * 3;
-      } else {
-        offset = 0xB4 + 0x5A + 9 * row + (col - 10) * 3;
-      }
-    }
-
-    // TO DO: incorporate RGB order here
-    int8_t r_off, g_off, b_off;
-    if ((col == 12) || (col % 2 == 1)) { // odds + last col
-      r_off = 1;
-      g_off = 0;
-      b_off = 2;
-    } else { // evens;
-      r_off = 2;
-      g_off = 1;
-      b_off = 0;
-    }
-
+    uint16_t offset = (x + ((x < 10) ? (y * 10) : (80 + y * 3))) * 3;
     // Serial.println(offset, HEX);
 
-    // Expand 5/6 bits of color components to 8 bits and store:
     uint8_t *ptr = &ledbuf[1 + offset];
-    ptr[r_off] = r;
-    ptr[g_off] = g;
-    ptr[b_off] = b;
+    if ((x & 1) || (x == 12)) { // Odd columns + last column
+      ptr[rOffset] = b;         // Flip color order vs constructor
+      ptr[gOffset] = r;
+      ptr[bOffset] = g;
+    } else {            // Even columns
+      ptr[rOffset] = r; // Color order follows constructor
+      ptr[gOffset] = g;
+      ptr[bOffset] = b;
+    }
   }
 }
 

--- a/Adafruit_IS31FL3741.cpp
+++ b/Adafruit_IS31FL3741.cpp
@@ -632,7 +632,7 @@ void Adafruit_IS31FL3741_QT::drawPixel(int16_t x, int16_t y, uint16_t color) {
     if ((x & 1) || (x == 12)) { // Odd columns + last column
       // Rearrange color order vs constructor. Not a simple swap,
       // needs to pass through table, or essentially (n + 2) % 3.
-      static const uint8_t remap[] = { 2, 0, 1 };
+      static const uint8_t remap[] = {2, 0, 1};
       setLEDPWM(offset + remap[rOffset], r);
       setLEDPWM(offset + remap[gOffset], g);
       setLEDPWM(offset + remap[bOffset], b);
@@ -678,7 +678,7 @@ void Adafruit_IS31FL3741_QT_buffered::drawPixel(int16_t x, int16_t y,
     if ((x & 1) || (x == 12)) { // Odd columns + last column
       // Rearrange color order vs constructor. Not a simple swap,
       // needs to pass through table, or essentially (n + 2) % 3.
-      static const uint8_t remap[] = { 2, 0, 1 };
+      static const uint8_t remap[] = {2, 0, 1};
       ptr[remap[rOffset]] = r;
       ptr[remap[gOffset]] = g;
       ptr[remap[bOffset]] = b;

--- a/Adafruit_IS31FL3741.cpp
+++ b/Adafruit_IS31FL3741.cpp
@@ -469,8 +469,9 @@ void Adafruit_IS31FL3741_buffered::show(void) {
             function can be used across subclasses.
 */
 /**************************************************************************/
-Adafruit_IS31FL3741_colorGFX::Adafruit_IS31FL3741_colorGFX(uint8_t width, uint8_t height,
-                                                 uint8_t order)
+Adafruit_IS31FL3741_colorGFX::Adafruit_IS31FL3741_colorGFX(uint8_t width,
+                                                           uint8_t height,
+                                                           uint8_t order)
     : Adafruit_IS31FL3741(), Adafruit_IS31FL3741_ColorOrder(order),
       Adafruit_GFX(width, height) {}
 
@@ -1284,47 +1285,43 @@ Adafruit_IS31FL3741_GlassesRightRing_buffered::
         Adafruit_IS31FL3741_buffered *controller)
     : Adafruit_IS31FL3741_GlassesRing_buffered(controller, true) {}
 
-
 // NEW EYELIGHTS CODE
-
 
 /**************************************************************************/
 /*!
     @brief  Constructor for EyeLights LED ring. Not invoked by user code.
     @param  isRight  true if right ring, false if left.
+    @param  order    RGB color order, one of the IS3741_* color defines.
 */
 /**************************************************************************/
-Adafruit_EyeLights_Ring_Base::Adafruit_EyeLights_Ring_Base(bool isRight, uint8_t order) : Adafruit_IS31FL3741_ColorOrder(order), ring_map(isRight ? right_ring_map : left_ring_map) {
-}
+Adafruit_EyeLights_Ring_Base::Adafruit_EyeLights_Ring_Base(bool isRight,
+                                                           uint8_t order)
+    : Adafruit_IS31FL3741_ColorOrder(order),
+      ring_map(isRight ? right_ring_map : left_ring_map) {}
 
-void Adafruit_EyeLights_Ring::setPixelColor(int16_t n, uint32_t color) {
-}
+void Adafruit_EyeLights_Ring::setPixelColor(int16_t n, uint32_t color) {}
 
-void Adafruit_EyeLights_Ring::fill(uint32_t color) {
-}
+void Adafruit_EyeLights_Ring::fill(uint32_t color) {}
 
-void Adafruit_EyeLights_Ring_buffered::setPixelColor(int16_t n, uint32_t color) {
-}
+void Adafruit_EyeLights_Ring_buffered::setPixelColor(int16_t n,
+                                                     uint32_t color) {}
 
-void Adafruit_EyeLights_Ring_buffered::fill(uint32_t color) {
-}
+void Adafruit_EyeLights_Ring_buffered::fill(uint32_t color) {}
 
-Adafruit_EyeLights_Base::Adafruit_EyeLights_Base(bool withCanvas) {
-}
+Adafruit_EyeLights_Base::Adafruit_EyeLights_Base(bool withCanvas) {}
 
-Adafruit_EyeLights::Adafruit_EyeLights(bool withCanvas, uint8_t order) : Adafruit_EyeLights_Base(withCanvas), Adafruit_IS31FL3741_colorGFX(18, 5, order), left_ring(false, order), right_ring(true, order) {
-}
+Adafruit_EyeLights::Adafruit_EyeLights(bool withCanvas, uint8_t order)
+    : Adafruit_EyeLights_Base(withCanvas),
+      Adafruit_IS31FL3741_colorGFX(18, 5, order), left_ring(false, order),
+      right_ring(true, order) {}
 
-void Adafruit_EyeLights::drawPixel(int16_t x, int16_t y, uint16_t color) {
-}
+void Adafruit_EyeLights::drawPixel(int16_t x, int16_t y, uint16_t color) {}
 
-Adafruit_EyeLights_buffered::Adafruit_EyeLights_buffered(bool withCanvas, uint8_t order) : Adafruit_EyeLights_Base(withCanvas), Adafruit_IS31FL3741_colorGFX_buffered(18, 5, order), left_ring(false, order), right_ring(true, order) {
-}
+Adafruit_EyeLights_buffered::Adafruit_EyeLights_buffered(bool withCanvas,
+                                                         uint8_t order)
+    : Adafruit_EyeLights_Base(withCanvas),
+      Adafruit_IS31FL3741_colorGFX_buffered(18, 5, order),
+      left_ring(false, order), right_ring(true, order) {}
 
-void Adafruit_EyeLights_buffered::drawPixel(int16_t x, int16_t y, uint16_t color) {
-}
-
-
-
-
-
+void Adafruit_EyeLights_buffered::drawPixel(int16_t x, int16_t y,
+                                            uint16_t color) {}

--- a/Adafruit_IS31FL3741.cpp
+++ b/Adafruit_IS31FL3741.cpp
@@ -693,155 +693,156 @@ void Adafruit_IS31FL3741_QT_buffered::drawPixel(int16_t x, int16_t y,
 // the EyeLights classes.
 
 // Remap table for pixel (X,Y) positions to LED indices, for drawPixel()
-// functions.
-// THESE ARE IN BRG ORDER
+// functions. LED indices are for blue, green, red for the EyeLights as
+// they originally shipped, hence default IS3741_BGR order in constructor,
+// to match the QT matrix LEDs. If there's a switch to different LEDs in
+// the future, pass a different order to the constructor.
 static const uint16_t PROGMEM glassesmatrix_ledmap[18 * 5 * 3] = {
     65535, 65535, 65535, // (0,0) (clipped, corner)
-    10,    9,     8,     // (0,0) / right ring pixel 20
-    13,    12,    11,    // (0,2) / 19
-    16,    15,    14,    // (0,3) / 18
-    4,     3,     2,     // (0,4) / 17
-    217,   216,   215,   // (1,0) / right ring pixel #21
-    220,   219,   218,   // (1,1)
-    223,   222,   221,   // (1,2)
-    226,   225,   224,   // (1,3)
-    214,   213,   212,   // (1,4)
-    187,   186,   185,   // (2,0)
-    190,   189,   188,   // (2,1)
-    193,   192,   191,   // (2,2)
-    196,   195,   194,   // (2,3)
-    184,   183,   182,   // (2,4)
-    37,    36,    35,    // (3,0)
-    40,    39,    38,    // (3,1)
-    43,    42,    41,    // (3,2)
-    46,    45,    44,    // (3,3)
-    34,    33,    32,    // (3,4)
-    67,    66,    65,    // (4,0)
-    70,    69,    68,    // (4,1)
-    73,    72,    71,    // (4,2)
-    76,    75,    74,    // (4,3)
-    64,    63,    62,    // (4,4)
-    97,    96,    95,    // (5,0)
-    100,   99,    98,    // (5,1)
-    103,   102,   101,   // (5,2)
-    106,   105,   104,   // (5,3)
-    94,    93,    92,    // (5,4)
-    127,   126,   125,   // (6,0) / right ring pixel 3
-    130,   129,   128,   // (6,1)
-    133,   132,   131,   // (6,2)
-    136,   135,   134,   // (6,3)
-    124,   123,   122,   // (6,4)
-    157,   156,   155,   // (7,0)
-    160,   159,   158,   // (7,1)
-    163,   162,   161,   // (7,2) / right ring pixel 5
-    166,   165,   164,   // (7,3) / 6
-    244,   243,   242,   // (7,4) / 7
-    247,   246,   245,   // (8,0)
-    250,   249,   248,   // (8,1)
-    253,   252,   251,   // (8,2)
-    256,   255,   254,   // (8,3)
+    10,    8,     9,     // (0,1) / right ring pixel 20
+    13,    11,    12,    // (0,2) / 19
+    16,    14,    15,    // (0,3) / 18
+    4,     2,     3,     // (0,4) / 17
+    217,   215,   216,   // (1,0) / right ring pixel #21
+    220,   218,   219,   // (1,1)
+    223,   221,   222,   // (1,2)
+    226,   224,   225,   // (1,3)
+    214,   212,   213,   // (1,4)
+    187,   185,   186,   // (2,0)
+    190,   188,   189,   // (2,1)
+    193,   191,   192,   // (2,2)
+    196,   194,   195,   // (2,3)
+    184,   182,   183,   // (2,4)
+    37,    35,    36,    // (3,0)
+    40,    38,    39,    // (3,1)
+    43,    41,    42,    // (3,2)
+    46,    44,    45,    // (3,3)
+    34,    32,    33,    // (3,4)
+    67,    65,    66,    // (4,0)
+    70,    68,    69,    // (4,1)
+    73,    71,    72,    // (4,2)
+    76,    74,    75,    // (4,3)
+    64,    62,    63,    // (4,4)
+    97,    95,    96,    // (5,0)
+    100,   98,    99,    // (5,1)
+    103,   101,   102,   // (5,2)
+    106,   104,   105,   // (5,3)
+    94,    92,    93,    // (5,4)
+    127,   125,   126,   // (6,0) / right ring pixel 3
+    130,   128,   129,   // (6,1)
+    133,   131,   132,   // (6,2)
+    136,   134,   135,   // (6,3)
+    124,   122,   123,   // (6,4)
+    157,   155,   156,   // (7,0)
+    160,   158,   159,   // (7,1)
+    163,   161,   162,   // (7,2) / right ring pixel 5
+    166,   164,   165,   // (7,3) / 6
+    244,   242,   243,   // (7,4) / 7
+    247,   245,   246,   // (8,0)
+    250,   248,   249,   // (8,1)
+    253,   251,   252,   // (8,2)
+    256,   254,   255,   // (8,3)
     65535, 65535, 65535, // (8,4) (clipped, nose bridge)
-    345,   346,   347,   // (9,0)
-    342,   343,   344,   // (9,1)
-    267,   268,   269,   // (9,2)
-    263,   264,   265,   // (9,3)
+    345,   347,   346,   // (9,0)
+    342,   344,   343,   // (9,1)
+    267,   269,   268,   // (9,2)
+    263,   265,   264,   // (9,3)
     65535, 65535, 65535, // (9,4) (clipped, nose bridge)
-    336,   337,   338,   // (10,0)
-    333,   334,   335,   // (10,1)
-    237,   238,   239,   // (10,2) / left ring pixel 19
-    233,   234,   235,   // (10,3) / 18
-    348,   349,   262,   // (10,4) / 17
-    327,   328,   329,   // (11,0) / left ring pixel 21
-    324,   325,   326,   // (11,1)
-    207,   208,   209,   // (11,2)
-    203,   204,   205,   // (11,3)
-    330,   331,   202,   // (11,4)
-    318,   319,   320,   // (12,0)
-    315,   316,   317,   // (12,1)
-    177,   178,   179,   // (12,2)
-    173,   174,   175,   // (12,3)
-    321,   322,   172,   // (12,4)
-    309,   310,   311,   // (13,0)
-    306,   307,   308,   // (13,1)
-    147,   148,   149,   // (13,2)
-    143,   144,   145,   // (13,3)
-    312,   313,   142,   // (13,4)
-    300,   301,   302,   // (14,0)
-    297,   298,   299,   // (14,1)
-    117,   118,   119,   // (14,2)
-    113,   114,   115,   // (14,3)
-    303,   304,   112,   // (14,4)
-    291,   292,   293,   // (15,0)
-    288,   289,   290,   // (15,1)
-    87,    88,    89,    // (15,2)
-    83,    84,    85,    // (15,3)
-    294,   295,   82,    // (15,4)
-    282,   283,   284,   // (16,0) / left ring pixel 3
-    279,   280,   281,   // (16,1)
-    57,    58,    59,    // (16,2)
-    53,    54,    55,    // (16,3)
-    285,   286,   52,    // (16,4)
+    336,   338,   337,   // (10,0)
+    333,   335,   334,   // (10,1)
+    237,   239,   238,   // (10,2) / left ring pixel 19
+    233,   235,   234,   // (10,3) / 18
+    348,   262,   349,   // (10,4) / 17
+    327,   329,   328,   // (11,0) / left ring pixel 21
+    324,   326,   325,   // (11,1)
+    207,   209,   208,   // (11,2)
+    203,   205,   204,   // (11,3)
+    330,   202,   331,   // (11,4)
+    318,   320,   319,   // (12,0)
+    315,   317,   316,   // (12,1)
+    177,   179,   178,   // (12,2)
+    173,   175,   174,   // (12,3)
+    321,   172,   322,   // (12,4)
+    309,   311,   310,   // (13,0)
+    306,   308,   307,   // (13,1)
+    147,   149,   148,   // (13,2)
+    143,   145,   144,   // (13,3)
+    312,   142,   313,   // (13,4)
+    300,   302,   301,   // (14,0)
+    297,   299,   298,   // (14,1)
+    117,   119,   118,   // (14,2)
+    113,   115,   114,   // (14,3)
+    303,   112,   304,   // (14,4)
+    291,   293,   292,   // (15,0)
+    288,   290,   289,   // (15,1)
+    87,    89,    88,    // (15,2)
+    83,    85,    84,    // (15,3)
+    294,   82,    295,   // (15,4)
+    282,   284,   283,   // (16,0) / left ring pixel 3
+    279,   281,   280,   // (16,1)
+    57,    59,    58,    // (16,2)
+    53,    55,    54,    // (16,3)
+    285,   52,    286,   // (16,4)
     65535, 65535, 65535, // (17,0) (clipped, corner)
-    270,   271,   272,   // (17,1) / left ring pixel 4
-    27,    28,    29,    // (17,2) / 5
-    23,    24,    25,    // (17,3) / 6
-    276,   277,   22,    // (17,4) / 7
+    270,   272,   271,   // (17,1) / left ring pixel 4
+    27,    29,    28,    // (17,2) / 5
+    23,    25,    24,    // (17,3) / 6
+    276,   22,    277,   // (17,4) / 7
 };
 
 // Remap tables for LED ring pixel positions to LED indices, for
 // setPixelColor() functions.
-// THESE ARE IN BRG ORDER
 static const uint16_t PROGMEM left_ring_map[24 * 3] = {
-    341, 211, 210, // 0
-    332, 181, 180, // 1
-    323, 151, 150, // 2
-    127, 126, 125, // 3
-    154, 153, 152, // 4
-    163, 162, 161, // 5
-    166, 165, 164, // 6
-    244, 243, 242, // 7
-    259, 258, 257, // 8
-    169, 168, 167, // 9
-    139, 138, 137, // 10
-    109, 108, 107, // 11
-    79,  78,  77,  // 12
-    49,  48,  47,  // 13
-    199, 198, 197, // 14
-    229, 228, 227, // 15
-    19,  18,  17,  // 16
-    4,   3,   2,   // 17
-    16,  15,  14,  // 18
-    13,  12,  11,  // 19
-    10,  9,   8,   // 20
-    217, 216, 215, // 21
-    7,   6,   5,   // 22
-    350, 241, 240, // 23
+    341, 210, 211, // 0
+    332, 180, 181, // 1
+    323, 150, 151, // 2
+    127, 125, 126, // 3
+    154, 152, 153, // 4
+    163, 161, 162, // 5
+    166, 164, 165, // 6
+    244, 242, 243, // 7
+    259, 257, 258, // 8
+    169, 167, 168, // 9
+    139, 137, 138, // 10
+    109, 107, 108, // 11
+    79,  77,  78,  // 12
+    49,  47,  48,  // 13
+    199, 197, 198, // 14
+    229, 227, 228, // 15
+    19,  17,  18,  // 16
+    4,   2,   3,   // 17
+    16,  14,  15,  // 18
+    13,  11,  12,  // 19
+    10,  8,   9,   // 20
+    217, 215, 216, // 21
+    7,   5,   6,   // 22
+    350, 240, 241, // 23
 };
 static const uint16_t PROGMEM right_ring_map[24 * 3] = {
-    287, 31,  30,  // 0
-    278, 1,   0,   // 1
-    273, 274, 275, // 2
-    282, 283, 284, // 3
-    270, 271, 272, // 4
-    27,  28,  29,  // 5
-    23,  24,  25,  // 6
-    276, 277, 22,  // 7
-    20,  21,  26,  // 8
-    50,  51,  56,  // 9
-    80,  81,  86,  // 10
-    110, 111, 116, // 11
-    140, 141, 146, // 12
-    170, 171, 176, // 13
-    200, 201, 206, // 14
-    230, 231, 236, // 15
-    260, 261, 266, // 16
-    348, 349, 262, // 17
-    233, 234, 235, // 18
-    237, 238, 239, // 19
-    339, 340, 232, // 20
-    327, 328, 329, // 21
-    305, 91,  90,  // 22
-    296, 61,  60,  // 23
+    287, 30,  31,  // 0
+    278, 0,   1,   // 1
+    273, 275, 274, // 2
+    282, 284, 283, // 3
+    270, 272, 271, // 4
+    27,  29,  28,  // 5
+    23,  25,  24,  // 6
+    276, 22,  277, // 7
+    20,  26,  21,  // 8
+    50,  56,  51,  // 9
+    80,  86,  81,  // 10
+    110, 116, 111, // 11
+    140, 146, 141, // 12
+    170, 176, 171, // 13
+    200, 206, 201, // 14
+    230, 236, 231, // 15
+    260, 266, 261, // 16
+    348, 262, 349, // 17
+    233, 235, 234, // 18
+    237, 239, 238, // 19
+    339, 232, 340, // 20
+    327, 329, 328, // 21
+    305, 90,  91,  // 22
+    296, 60,  61,  // 23
 };
 
 // GFXcanvas16 is RGB565 color while the LEDs are RGB888, so during 1:3
@@ -980,10 +981,11 @@ void Adafruit_EyeLights::drawPixel(int16_t x, int16_t y, uint16_t color) {
     _IS31_ROTATE_(x, y);           // Handle GFX-style soft rotation
     _IS31_EXPAND_(color, r, g, b); // Expand GFX's RGB565 color to RGB888
     x = (x * 5 + y) * 3;           // Starting index into the led table above
-    uint16_t bidx = pgm_read_word(&glassesmatrix_ledmap[x + rOffset]);
-    if (bidx != 65535) {
-      uint16_t ridx = pgm_read_word(&glassesmatrix_ledmap[x + gOffset]);
-      uint16_t gidx = pgm_read_word(&glassesmatrix_ledmap[x + bOffset]);
+                                   // table is brg
+    uint16_t ridx = pgm_read_word(&glassesmatrix_ledmap[x + rOffset]);
+    if (ridx != 65535) {
+      uint16_t gidx = pgm_read_word(&glassesmatrix_ledmap[x + gOffset]);
+      uint16_t bidx = pgm_read_word(&glassesmatrix_ledmap[x + bOffset]);
       setLEDPWM(ridx, r);
       setLEDPWM(gidx, g);
       setLEDPWM(bidx, b);
@@ -1021,10 +1023,10 @@ void Adafruit_EyeLights::scale(void) {
           ptr += canvas->width(); // Advance one scan line
         }
         uint16_t base = (x * 5 + y) * 3; // Offset into ledmap
-        uint16_t bidx = pgm_read_word(&glassesmatrix_ledmap[base + rOffset]);
-        if (bidx != 65535) {
-          uint16_t ridx = pgm_read_word(&glassesmatrix_ledmap[base + gOffset]);
-          uint16_t gidx = pgm_read_word(&glassesmatrix_ledmap[base + bOffset]);
+        uint16_t ridx = pgm_read_word(&glassesmatrix_ledmap[base + rOffset]);
+        if (ridx != 65535) {
+          uint16_t gidx = pgm_read_word(&glassesmatrix_ledmap[base + gOffset]);
+          uint16_t bidx = pgm_read_word(&glassesmatrix_ledmap[base + bOffset]);
           setLEDPWM(ridx, pgm_read_byte(&gammaRB[rsum]));
           setLEDPWM(gidx, pgm_read_byte(&gammaG[gsum]));
           setLEDPWM(bidx, pgm_read_byte(&gammaRB[bsum]));
@@ -1092,10 +1094,10 @@ void Adafruit_EyeLights_buffered::drawPixel(int16_t x, int16_t y,
   if ((x >= 0) && (x < width()) && (y >= 0) && (y < height())) {
     _IS31_ROTATE_(x, y); // Handle GFX-style soft rotation
     x = (x * 5 + y) * 3; // Base index into ledmap
-    uint16_t bidx = pgm_read_word(&glassesmatrix_ledmap[x + rOffset]);
-    if (bidx != 65535) {
-      uint16_t ridx = pgm_read_word(&glassesmatrix_ledmap[x + gOffset]);
-      uint16_t gidx = pgm_read_word(&glassesmatrix_ledmap[x + bOffset]);
+    uint16_t ridx = pgm_read_word(&glassesmatrix_ledmap[x + rOffset]);
+    if (ridx != 65535) {
+      uint16_t gidx = pgm_read_word(&glassesmatrix_ledmap[x + gOffset]);
+      uint16_t bidx = pgm_read_word(&glassesmatrix_ledmap[x + bOffset]);
       uint8_t *ledbuf = getBuffer();
       _IS31_EXPAND_(color, r, g, b); // Expand GFX's RGB565 color to RGB888
       ledbuf[ridx] = r;
@@ -1137,10 +1139,10 @@ void Adafruit_EyeLights_buffered::scale(void) {
           ptr += canvas->width(); // Advance one scan line
         }
         uint16_t base = (x * 5 + y) * 3; // Offset into ledmap
-        uint16_t bidx = pgm_read_word(&glassesmatrix_ledmap[base + rOffset]);
-        if (bidx != 65535) {
-          uint16_t ridx = pgm_read_word(&glassesmatrix_ledmap[base + gOffset]);
-          uint16_t gidx = pgm_read_word(&glassesmatrix_ledmap[base + bOffset]);
+        uint16_t ridx = pgm_read_word(&glassesmatrix_ledmap[base + rOffset]);
+        if (ridx != 65535) {
+          uint16_t gidx = pgm_read_word(&glassesmatrix_ledmap[base + gOffset]);
+          uint16_t bidx = pgm_read_word(&glassesmatrix_ledmap[base + bOffset]);
           ledbuf[ridx] = pgm_read_byte(&gammaRB[rsum]);
           ledbuf[gidx] = pgm_read_byte(&gammaG[gsum]);
           ledbuf[bidx] = pgm_read_byte(&gammaRB[bsum]);
@@ -1171,13 +1173,13 @@ void Adafruit_IS31FL3741_GlassesMatrix::drawPixel(int16_t x, int16_t y,
     _IS31_EXPAND_(color, r, g, b); // Expand GFX's RGB565 color to RGB888
 
     x = (x * 5 + y) * 3; // Starting index into the led table above
-    uint16_t bidx = pgm_read_word(&glassesmatrix_ledmap[x]);
-    if (bidx != 65535) {
-      uint16_t ridx = pgm_read_word(&glassesmatrix_ledmap[x + 1]);
-      uint16_t gidx = pgm_read_word(&glassesmatrix_ledmap[x + 2]);
-      _is31->setLEDPWM(bidx, b);
+    uint16_t ridx = pgm_read_word(&glassesmatrix_ledmap[x + 2]);
+    if (ridx != 65535) {
+      uint16_t gidx = pgm_read_word(&glassesmatrix_ledmap[x + 1]);
+      uint16_t bidx = pgm_read_word(&glassesmatrix_ledmap[x]);
       _is31->setLEDPWM(ridx, r);
       _is31->setLEDPWM(gidx, g);
+      _is31->setLEDPWM(bidx, b);
     }
 
     /*
@@ -1219,9 +1221,9 @@ void Adafruit_IS31FL3741_GlassesRing::setPixelColor(int16_t n, uint32_t color) {
     g = (((uint16_t)((color >> 8) & 0xFF)) * _brightness) >> 8;
     b = (((uint16_t)(color & 0xFF)) * _brightness) >> 8;
     n *= 3;
-    _is31->setLEDPWM(pgm_read_word(&ring_map[n]), b);
-    _is31->setLEDPWM(pgm_read_word(&ring_map[n + 1]), r);
-    _is31->setLEDPWM(pgm_read_word(&ring_map[n + 2]), g);
+    _is31->setLEDPWM(pgm_read_word(&ring_map[n]), r);
+    _is31->setLEDPWM(pgm_read_word(&ring_map[n + 1]), g);
+    _is31->setLEDPWM(pgm_read_word(&ring_map[n + 2]), b);
   }
 }
 
@@ -1238,9 +1240,9 @@ void Adafruit_IS31FL3741_GlassesRing::fill(uint32_t color) {
   b = (((uint16_t)(color & 0xFF)) * _brightness) >> 8;
 
   for (uint8_t n = 0; n < 24 * 3; n += 3) {
-    _is31->setLEDPWM(pgm_read_word(&ring_map[n]), b);
-    _is31->setLEDPWM(pgm_read_word(&ring_map[n + 1]), r);
-    _is31->setLEDPWM(pgm_read_word(&ring_map[n + 2]), g);
+    _is31->setLEDPWM(pgm_read_word(&ring_map[n]), r);
+    _is31->setLEDPWM(pgm_read_word(&ring_map[n + 1]), g);
+    _is31->setLEDPWM(pgm_read_word(&ring_map[n + 2]), b);
   }
 }
 
@@ -1283,9 +1285,9 @@ void Adafruit_IS31FL3741_GlassesMatrix_buffered::drawPixel(int16_t x, int16_t y,
     _IS31_ROTATE_(x, y); // Handle GFX-style soft rotation
     x = (x * 5 + y) * 3; // Base index into ledmap
     uint16_t bidx = pgm_read_word(&glassesmatrix_ledmap[x]);
-    if (bidx != 65535) {
-      uint16_t ridx = pgm_read_word(&glassesmatrix_ledmap[x + 1]);
-      uint16_t gidx = pgm_read_word(&glassesmatrix_ledmap[x + 2]);
+    if (bidx != 65535) { // Tables are BGR order
+      uint16_t gidx = pgm_read_word(&glassesmatrix_ledmap[x + 1]);
+      uint16_t ridx = pgm_read_word(&glassesmatrix_ledmap[x + 2]);
       uint8_t *ledbuf = _is31->getBuffer();
       _IS31_EXPAND_(color, r, g, b); // Expand GFX's RGB565 color to RGB888
       ledbuf[ridx] = r;
@@ -1328,9 +1330,9 @@ void Adafruit_IS31FL3741_GlassesMatrix_buffered::scale(void) {
         }
         uint16_t base = (x * 5 + y) * 3; // Offset into ledmap
         uint16_t bidx = pgm_read_word(&glassesmatrix_ledmap[base]);
-        if (bidx != 65535) {
-          uint16_t ridx = pgm_read_word(&glassesmatrix_ledmap[base + 1]);
-          uint16_t gidx = pgm_read_word(&glassesmatrix_ledmap[base + 2]);
+        if (bidx != 65535) { // Tables are BGR order
+          uint16_t gidx = pgm_read_word(&glassesmatrix_ledmap[base + 1]);
+          uint16_t ridx = pgm_read_word(&glassesmatrix_ledmap[base + 2]);
           ledbuf[ridx] = pgm_read_byte(&gammaRB[rsum]);
           ledbuf[gidx] = pgm_read_byte(&gammaG[gsum]);
           ledbuf[bidx] = pgm_read_byte(&gammaRB[bsum]);
@@ -1369,9 +1371,9 @@ void Adafruit_IS31FL3741_GlassesRing_buffered::setPixelColor(int16_t n,
     uint8_t g = (((uint16_t)((color >> 8) & 0xFF)) * _brightness) >> 8;
     uint8_t b = (((uint16_t)(color & 0xFF)) * _brightness) >> 8;
     n *= 3;
-    ledbuf[pgm_read_word(&ring_map[n])] = r;
+    ledbuf[pgm_read_word(&ring_map[n + 2])] = r; // Tables are BGR order
     ledbuf[pgm_read_word(&ring_map[n + 1])] = g;
-    ledbuf[pgm_read_word(&ring_map[n + 2])] = b;
+    ledbuf[pgm_read_word(&ring_map[n])] = b;
   }
 }
 
@@ -1388,8 +1390,8 @@ void Adafruit_IS31FL3741_GlassesRing_buffered::fill(uint32_t color) {
   uint8_t g = (((uint16_t)((color >> 8) & 0xFF)) * _brightness) >> 8;
   uint8_t b = (((uint16_t)(color & 0xFF)) * _brightness) >> 8;
   for (uint8_t n = 0; n < 24 * 3; n += 3) {
-    ledbuf[pgm_read_word(&ring_map[n])] = r;
+    ledbuf[pgm_read_word(&ring_map[n + 2])] = r; // Tables are BGR order
     ledbuf[pgm_read_word(&ring_map[n + 1])] = g;
-    ledbuf[pgm_read_word(&ring_map[n + 2])] = b;
+    ledbuf[pgm_read_word(&ring_map[n])] = b;
   }
 }

--- a/Adafruit_IS31FL3741.cpp
+++ b/Adafruit_IS31FL3741.cpp
@@ -553,7 +553,8 @@ void Adafruit_IS31FL3741_EVB::drawPixel(int16_t x, int16_t y, uint16_t color) {
     _IS31_EXPAND_(color, r, g, b); // Expand GFX's RGB565 color to RGB888
 
     // Map x/y to device-specific pixel layout
-    uint16_t offset = ((x > 9) ? (x + 80 + y * 3) : (x + y * 10)) * 3;
+    uint16_t offset = ((y > 2) ? (x * 10 + 12 - y) : (92 + x * 3 - y)) * 3;
+
     /*
     Serial.print("("); Serial.print(x);
     Serial.print(", "); Serial.print(y);
@@ -584,7 +585,8 @@ void Adafruit_IS31FL3741_EVB_buffered::drawPixel(int16_t x, int16_t y,
     _IS31_EXPAND_(color, r, g, b); // Expand GFX's RGB565 color to RGB888
 
     // Map x/y to device-specific pixel layout
-    uint16_t offset = ((x > 9) ? (x + 80 + y * 3) : (x + y * 10)) * 3;
+    uint16_t offset = ((y > 2) ? (x * 10 + 12 - y) : (92 + x * 3 - y)) * 3;
+
     /*
     Serial.print("("); Serial.print(x);
     Serial.print(", "); Serial.print(y);

--- a/Adafruit_IS31FL3741.cpp
+++ b/Adafruit_IS31FL3741.cpp
@@ -629,10 +629,13 @@ void Adafruit_IS31FL3741_QT::drawPixel(int16_t x, int16_t y, uint16_t color) {
     uint16_t offset = (x + ((x < 10) ? (y * 10) : (80 + y * 3))) * 3;
     // Serial.println(offset, HEX);
 
-    if ((x & 1) || (x == 12)) {       // Odd columns + last column
-      setLEDPWM(offset + rOffset, b); // Flip color order vs constructor
-      setLEDPWM(offset + gOffset, r);
-      setLEDPWM(offset + bOffset, g);
+    if ((x & 1) || (x == 12)) { // Odd columns + last column
+      // Rearrange color order vs constructor. Not a simple swap,
+      // needs to pass through table, or essentially (n + 2) % 3.
+      static const uint8_t remap[] = { 2, 0, 1 };
+      setLEDPWM(offset + remap[rOffset], r);
+      setLEDPWM(offset + remap[gOffset], g);
+      setLEDPWM(offset + remap[bOffset], b);
     } else {                          // Even columns
       setLEDPWM(offset + rOffset, r); // Color order follows constructor
       setLEDPWM(offset + gOffset, g);
@@ -673,9 +676,12 @@ void Adafruit_IS31FL3741_QT_buffered::drawPixel(int16_t x, int16_t y,
 
     uint8_t *ptr = &ledbuf[1 + offset];
     if ((x & 1) || (x == 12)) { // Odd columns + last column
-      ptr[rOffset] = b;         // Flip color order vs constructor
-      ptr[gOffset] = r;
-      ptr[bOffset] = g;
+      // Rearrange color order vs constructor. Not a simple swap,
+      // needs to pass through table, or essentially (n + 2) % 3.
+      static const uint8_t remap[] = { 2, 0, 1 };
+      ptr[remap[rOffset]] = r;
+      ptr[remap[gOffset]] = g;
+      ptr[remap[bOffset]] = b;
     } else {            // Even columns
       ptr[rOffset] = r; // Color order follows constructor
       ptr[gOffset] = g;

--- a/Adafruit_IS31FL3741.cpp
+++ b/Adafruit_IS31FL3741.cpp
@@ -981,7 +981,6 @@ static const uint8_t PROGMEM gammaG[] = {
     227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241,
     242, 243, 244, 245, 246, 248, 249, 250, 251, 252, 253, 254, 255};
 
-
 // NEW EYELIGHTS CODE ----
 
 /**************************************************************************/
@@ -1042,7 +1041,7 @@ void Adafruit_EyeLights_Ring_buffered::setPixelColor(int16_t n,
                                                      uint32_t color) {
   if ((n >= 0) && (n < 24)) {
     Adafruit_EyeLights_buffered *eyelights =
-      (Adafruit_EyeLights_buffered *)parent;
+        (Adafruit_EyeLights_buffered *)parent;
     uint8_t *ledbuf = eyelights->getBuffer();
     _IS31_SCALE_RGB_(color, r, g, b, _brightness);
     n *= 3;
@@ -1061,7 +1060,7 @@ void Adafruit_EyeLights_Ring_buffered::setPixelColor(int16_t n,
 /**************************************************************************/
 void Adafruit_EyeLights_Ring_buffered::fill(uint32_t color) {
   Adafruit_EyeLights_buffered *eyelights =
-    (Adafruit_EyeLights_buffered *)parent;
+      (Adafruit_EyeLights_buffered *)parent;
   uint8_t *ledbuf = eyelights->getBuffer();
   _IS31_SCALE_RGB_(color, r, g, b, _brightness);
   for (uint8_t n = 0; n < 24 * 3; n += 3) {
@@ -1075,7 +1074,7 @@ void Adafruit_EyeLights::drawPixel(int16_t x, int16_t y, uint16_t color) {
   if ((x >= 0) && (y >= 0) && (x < width()) && (y < height())) {
     _IS31_ROTATE_(x, y);           // Handle GFX-style soft rotation
     _IS31_EXPAND_(color, r, g, b); // Expand GFX's RGB565 color to RGB888
-    x = (x * 5 + y) * 3; // Starting index into the led table above
+    x = (x * 5 + y) * 3;           // Starting index into the led table above
     uint16_t bidx = pgm_read_word(&glassesmatrix_ledmap[x + rOffset]);
     if (bidx != 65535) {
       uint16_t ridx = pgm_read_word(&glassesmatrix_ledmap[x + gOffset]);
@@ -1182,7 +1181,6 @@ void Adafruit_EyeLights_buffered::scale(void) {
   }
 }
 
-
 // LED GLASSES (DIRECT) ----------------------------------------------------
 
 // This is olde style but kept around for backwards compatibility.
@@ -1199,7 +1197,6 @@ Adafruit_IS31FL3741_GlassesMatrix::Adafruit_IS31FL3741_GlassesMatrix(
     : Adafruit_GFX(18, 5) {
   _is31 = controller;
 }
-
 
 /**************************************************************************/
 /*!
@@ -1236,7 +1233,6 @@ void Adafruit_IS31FL3741_GlassesMatrix::drawPixel(int16_t x, int16_t y,
     */
   }
 }
-
 
 /**************************************************************************/
 /*!
@@ -1362,7 +1358,6 @@ void Adafruit_IS31FL3741_GlassesMatrix_buffered::drawPixel(int16_t x, int16_t y,
     }
   }
 }
-
 
 /**************************************************************************/
 /*!
@@ -1493,7 +1488,3 @@ Adafruit_IS31FL3741_GlassesRightRing_buffered::
     Adafruit_IS31FL3741_GlassesRightRing_buffered(
         Adafruit_IS31FL3741_buffered *controller)
     : Adafruit_IS31FL3741_GlassesRing_buffered(controller, true) {}
-
-
-
-

--- a/Adafruit_IS31FL3741.cpp
+++ b/Adafruit_IS31FL3741.cpp
@@ -535,9 +535,9 @@ Adafruit_IS31FL3741_EVB::Adafruit_IS31FL3741_EVB(uint8_t order)
 /*!
     @brief  Adafruit GFX low level accessor - sets an RGB pixel value,
             handles rotation and pixel arrangement.
-    @param  x    The x position, starting with 0 for left-most side
-    @param  y    The y position, starting with 0 for top-most side
-    @param color 16-bit RGB565 packed color (expands to 888 for LEDs).
+    @param  x      The x position, starting with 0 for left-most side
+    @param  y      The y position, starting with 0 for top-most side
+    @param  color  16-bit RGB565 packed color (expands to 888 for LEDs).
 */
 /**************************************************************************/
 void Adafruit_IS31FL3741_EVB::drawPixel(int16_t x, int16_t y, uint16_t color) {
@@ -565,7 +565,6 @@ void Adafruit_IS31FL3741_EVB::drawPixel(int16_t x, int16_t y, uint16_t color) {
 /*!
     @brief  Constructor for Lumissil IS31FL3741 "official" evaluation board,
             13x9 pixels, buffered.
-
 */
 /**************************************************************************/
 Adafruit_IS31FL3741_EVB_buffered::Adafruit_IS31FL3741_EVB_buffered(
@@ -576,9 +575,9 @@ Adafruit_IS31FL3741_EVB_buffered::Adafruit_IS31FL3741_EVB_buffered(
 /*!
     @brief  Adafruit GFX low level accessor - sets an RGB pixel value,
             handles rotation and pixel arrangement.
-    @param  x    The x position, starting with 0 for left-most side
-    @param  y    The y position, starting with 0 for top-most side
-    @param color 16-bit RGB565 packed color (expands to 888 for LEDs).
+    @param  x      The x position, starting with 0 for left-most side
+    @param  y      The y position, starting with 0 for top-most side
+    @param  color  16-bit RGB565 packed color (expands to 888 for LEDs).
 */
 /**************************************************************************/
 void Adafruit_IS31FL3741_EVB_buffered::drawPixel(int16_t x, int16_t y,
@@ -617,9 +616,9 @@ Adafruit_IS31FL3741_QT::Adafruit_IS31FL3741_QT(uint8_t order)
 /*!
     @brief  Adafruit GFX low level accessor - sets an RGB pixel value,
             handles rotation and pixel arrangement.
-    @param  x     The x position, starting with 0 for left-most side.
-    @param  y     The y position, starting with 0 for top-most side.
-    @param  color 16-bit RGB565 packed color (expands to 888 for LEDs).
+    @param  x      The x position, starting with 0 for left-most side.
+    @param  y      The y position, starting with 0 for top-most side.
+    @param  color  16-bit RGB565 packed color (expands to 888 for LEDs).
 */
 /**************************************************************************/
 void Adafruit_IS31FL3741_QT::drawPixel(int16_t x, int16_t y, uint16_t color) {
@@ -680,7 +679,7 @@ void Adafruit_IS31FL3741_QT::drawPixel(int16_t x, int16_t y, uint16_t color) {
 
 /**************************************************************************/
 /*!
-    @brief Constructor for STEMMA QT version (13 x 9 LEDs), buffered.
+    @brief  Constructor for STEMMA QT version (13 x 9 LEDs), buffered.
 */
 /**************************************************************************/
 Adafruit_IS31FL3741_QT_buffered::Adafruit_IS31FL3741_QT_buffered(uint8_t order)
@@ -688,11 +687,11 @@ Adafruit_IS31FL3741_QT_buffered::Adafruit_IS31FL3741_QT_buffered(uint8_t order)
 
 /**************************************************************************/
 /*!
-    @brief Adafruit GFX low level accessor - sets an RGB pixel value,
-           handles rotation and pixel arrangement, unlike setLEDPWM.
-    @param x The x position, starting with 0 for left-most side
-    @param y The y position, starting with 0 for top-most side
-    @param color 16-bit RGB565 packed color (expands to 888 for LEDs).
+    @brief         Adafruit GFX low level accessor - sets an RGB pixel value,
+                   handles rotation and pixel arrangement, unlike setLEDPWM.
+    @param  x      The x position, starting with 0 for left-most side
+    @param  y      The y position, starting with 0 for top-most side
+    @param  color  16-bit RGB565 packed color (expands to 888 for LEDs).
 */
 /**************************************************************************/
 void Adafruit_IS31FL3741_QT_buffered::drawPixel(int16_t x, int16_t y,
@@ -759,7 +758,7 @@ void Adafruit_IS31FL3741_QT_buffered::drawPixel(int16_t x, int16_t y,
 
 /**************************************************************************/
 /*!
-    @brief Constructor for LED glasses (matrix portion, 18x5 LEDs)
+    @brief  Constructor for LED glasses (matrix portion, 18x5 LEDs)
     @param  controller  Pointer to core object (underlying hardware).
 */
 /**************************************************************************/
@@ -866,11 +865,11 @@ static const uint16_t PROGMEM glassesmatrix_ledmap[18 * 5 * 3] = {
 
 /**************************************************************************/
 /*!
-    @brief Adafruit GFX low level accessor - sets an RGB pixel value,
-           handles rotation and pixel arrangement, unlike setLEDPWM.
-    @param x The x position, starting with 0 for left-most side
-    @param y The y position, starting with 0 for top-most side
-    @param color 16-bit RGB565 packed color (expands to 888 for LEDs).
+    @brief         Adafruit GFX low level accessor - sets an RGB pixel value,
+                   handles rotation and pixel arrangement, unlike setLEDPWM.
+    @param  x      The x position, starting with 0 for left-most side
+    @param  y      The y position, starting with 0 for top-most side
+    @param  color  16-bit RGB565 packed color (expands to 888 for LEDs).
 */
 /**************************************************************************/
 void Adafruit_IS31FL3741_GlassesMatrix::drawPixel(int16_t x, int16_t y,
@@ -958,10 +957,10 @@ static const uint16_t PROGMEM right_ring_map[24 * 3] = {
 
 /**************************************************************************/
 /*!
-    @brief Constructor for glasses LED ring. Not invoked by user code;
-           use one of the subsequent subclasses for that.
-    @param controller  Pointer to Adafruit_IS31FL3741 object.
-    @param isRight     true if right ring, false if left.
+    @brief  Constructor for glasses LED ring. Not invoked by user code;
+            use one of the subsequent subclasses for that.
+    @param  controller  Pointer to Adafruit_IS31FL3741 object.
+    @param  isRight     true if right ring, false if left.
 */
 /**************************************************************************/
 Adafruit_IS31FL3741_GlassesRing::Adafruit_IS31FL3741_GlassesRing(
@@ -972,7 +971,7 @@ Adafruit_IS31FL3741_GlassesRing::Adafruit_IS31FL3741_GlassesRing(
 
 /**************************************************************************/
 /*!
-    @brief Set color of one pixel of one glasses ring.
+    @brief  Set color of one pixel of one glasses ring.
     @param  n      Index of pixel to set (0-23).
     @param  color  RGB888 (24-bit) color, a la NeoPixel.
 */
@@ -993,7 +992,7 @@ void Adafruit_IS31FL3741_GlassesRing::setPixelColor(int16_t n, uint32_t color) {
 /**************************************************************************/
 /*!
     @brief Fill all pixels of one glasses ring to same color.
-    @param color  RGB888 (24-bit) color, a la NeoPixel.
+    @param  color  RGB888 (24-bit) color, a la NeoPixel.
 */
 /**************************************************************************/
 void Adafruit_IS31FL3741_GlassesRing::fill(uint32_t color) {
@@ -1011,8 +1010,8 @@ void Adafruit_IS31FL3741_GlassesRing::fill(uint32_t color) {
 
 /**************************************************************************/
 /*!
-    @brief Constructor for glasses left LED ring.
-    @param controller  Pointer to Adafruit_IS31FL3741 object.
+    @brief  Constructor for glasses left LED ring.
+    @param  controller  Pointer to Adafruit_IS31FL3741 object.
 */
 /**************************************************************************/
 Adafruit_IS31FL3741_GlassesLeftRing::Adafruit_IS31FL3741_GlassesLeftRing(
@@ -1021,8 +1020,8 @@ Adafruit_IS31FL3741_GlassesLeftRing::Adafruit_IS31FL3741_GlassesLeftRing(
 
 /**************************************************************************/
 /*!
-    @brief Constructor for glasses right LED ring.
-    @param controller  Pointer to Adafruit_IS31FL3741 object.
+    @brief  Constructor for glasses right LED ring.
+    @param  controller  Pointer to Adafruit_IS31FL3741 object.
 */
 /**************************************************************************/
 Adafruit_IS31FL3741_GlassesRightRing::Adafruit_IS31FL3741_GlassesRightRing(
@@ -1033,7 +1032,7 @@ Adafruit_IS31FL3741_GlassesRightRing::Adafruit_IS31FL3741_GlassesRightRing(
 
 /**************************************************************************/
 /*!
-    @brief Constructor for buffered LED glasses (matrix portion, 18x5 LEDs)
+    @brief  Constructor for buffered LED glasses (matrix portion, 18x5 LEDs)
     @param  controller  Pointer to Adafruit_IS31FL3741_buffered object.
     @param  withCanvas  If true, allocate an additional GFXcanvas16 object
                         that's 3X the size of the LED matrix -- using the
@@ -1057,9 +1056,9 @@ Adafruit_IS31FL3741_GlassesMatrix_buffered::
     @brief  Adafruit GFX low level accessor for buffered glasses matrix -
             sets an RGB pixel value, handles rotation and pixel arrangement.
             No immediate effect on LEDs; must follow up with show().
-    @param x     X position, starting with 0 for left-most side
-    @param y     Y position, starting with 0 for top-most side
-    @param color 16-bit RGB565 packed color (expands to 888 for LEDs).
+    @param  x      X position, starting with 0 for left-most side
+    @param  y      Y position, starting with 0 for top-most side
+    @param  color  16-bit RGB565 packed color (expands to 888 for LEDs).
 */
 /**************************************************************************/
 void Adafruit_IS31FL3741_GlassesMatrix_buffered::drawPixel(int16_t x, int16_t y,
@@ -1195,10 +1194,10 @@ void Adafruit_IS31FL3741_GlassesMatrix_buffered::scale(void) {
 }
 /**************************************************************************/
 /*!
-    @brief Constructor for buffered glasses LED ring. Not invoked by user
-           code; use one of the subsequent subclasses for that.
-    @param controller  Pointer to Adafruit_IS31FL3741 object.
-    @param isRight     true if right ring, false if left.
+    @brief  Constructor for buffered glasses LED ring. Not invoked by user
+            code; use one of the subsequent subclasses for that.
+    @param  controller  Pointer to Adafruit_IS31FL3741 object.
+    @param  isRight     true if right ring, false if left.
 */
 /**************************************************************************/
 Adafruit_IS31FL3741_GlassesRing_buffered::
@@ -1210,8 +1209,8 @@ Adafruit_IS31FL3741_GlassesRing_buffered::
 
 /**************************************************************************/
 /*!
-    @brief Set color of one pixel of one buffered glasses ring.
-           No immediate effect on LEDs; must follow up with show().
+    @brief  Set color of one pixel of one buffered glasses ring.
+            No immediate effect on LEDs; must follow up with show().
     @param  n      Index of pixel to set (0-23).
     @param  color  RGB888 (24-bit) color, a la NeoPixel.
 */
@@ -1237,9 +1236,9 @@ void Adafruit_IS31FL3741_GlassesRing_buffered::setPixelColor(int16_t n,
 
 /**************************************************************************/
 /*!
-    @brief Fill all pixels of one glasses ring to same color.
-           No immediate effect on LEDs; must follow up with show().
-    @param color  RGB888 (24-bit) color, a la NeoPixel.
+    @brief  Fill all pixels of one glasses ring to same color.
+            No immediate effect on LEDs; must follow up with show().
+    @param  color  RGB888 (24-bit) color, a la NeoPixel.
 */
 /**************************************************************************/
 void Adafruit_IS31FL3741_GlassesRing_buffered::fill(uint32_t color) {
@@ -1258,8 +1257,8 @@ void Adafruit_IS31FL3741_GlassesRing_buffered::fill(uint32_t color) {
 
 /**************************************************************************/
 /*!
-    @brief Constructor for buffered glasses left LED ring.
-    @param controller  Pointer to Adafruit_IS31FL3741_buffered object.
+    @brief  Constructor for buffered glasses left LED ring.
+    @param  controller  Pointer to Adafruit_IS31FL3741_buffered object.
 */
 /**************************************************************************/
 Adafruit_IS31FL3741_GlassesLeftRing_buffered::
@@ -1269,8 +1268,8 @@ Adafruit_IS31FL3741_GlassesLeftRing_buffered::
 
 /**************************************************************************/
 /*!
-    @brief Constructor for buffered glasses right LED ring.
-    @param controller  Pointer to Adafruit_IS31FL3741_buffered object.
+    @brief  Constructor for buffered glasses right LED ring.
+    @param  controller  Pointer to Adafruit_IS31FL3741_buffered object.
 */
 /**************************************************************************/
 Adafruit_IS31FL3741_GlassesRightRing_buffered::
@@ -1278,27 +1277,24 @@ Adafruit_IS31FL3741_GlassesRightRing_buffered::
         Adafruit_IS31FL3741_buffered *controller)
     : Adafruit_IS31FL3741_GlassesRing_buffered(controller, true) {}
 
-
-
-
-
-
 // NEW EYELIGHTS CODE
 
 /**************************************************************************/
 /*!
     @brief  Constructor for EyeLights LED ring. Not invoked by user code.
+    @param  parent   void* pointer to parent EyeLights object this is
+                     attached to (may be direct or buffered, hence void*
+                     rather than specific type).
     @param  isRight  true if right ring, false if left.
-    @param  ptr      void* pointer to EyeLights object this is attached to.
 */
 /**************************************************************************/
-Adafruit_EyeLights_Ring_Base::Adafruit_EyeLights_Ring_Base(void *ptr,
+Adafruit_EyeLights_Ring_Base::Adafruit_EyeLights_Ring_Base(void *parent,
                                                            bool isRight)
-    : parent(ptr), ring_map(isRight ? right_ring_map : left_ring_map) {}
+    : parent(parent), ring_map(isRight ? right_ring_map : left_ring_map) {}
 
 /**************************************************************************/
 /*!
-    @brief  Set color of one pixel of one direct (unbuffered) glasses ring.
+    @brief  Set color of one pixel of one direct (unbuffered) EyeLights ring.
     @param  n      Index of pixel to set (0-23).
     @param  color  RGB888 (24-bit) color, a la NeoPixel.
 */
@@ -1310,46 +1306,31 @@ void Adafruit_EyeLights_Ring::setPixelColor(int16_t n, uint32_t color) {
     g = (((uint16_t)((color >> 8) & 0xFF)) * _brightness) >> 8;
     b = (((uint16_t)(color & 0xFF)) * _brightness) >> 8;
     n *= 3;
-    Adafruit_EyeLights *is31 = (Adafruit_EyeLights *)parent;
-    is31->setLEDPWM(pgm_read_word(&ring_map[n]), b);
-    is31->setLEDPWM(pgm_read_word(&ring_map[n + 1]), r);
-    is31->setLEDPWM(pgm_read_word(&ring_map[n + 2]), g);
+    Adafruit_EyeLights *eyelights = (Adafruit_EyeLights *)parent;
+    eyelights->setLEDPWM(pgm_read_word(&ring_map[n]), b);
+    eyelights->setLEDPWM(pgm_read_word(&ring_map[n + 1]), r);
+    eyelights->setLEDPWM(pgm_read_word(&ring_map[n + 2]), g);
   }
 }
 
-
-
-
-
-void Adafruit_EyeLights_Ring::fill(uint32_t color) {}
+void Adafruit_EyeLights_Ring::fill(uint32_t color) {
+  // TO DO
+}
 
 void Adafruit_EyeLights_Ring_buffered::setPixelColor(int16_t n,
-                                                     uint32_t color) {}
-
-void Adafruit_EyeLights_Ring_buffered::fill(uint32_t color) {}
-
-Adafruit_EyeLights_Base::Adafruit_EyeLights_Base(bool withCanvas) {
-  if (withCanvas) {
-    canvas = new GFXcanvas16(18 * 3, 5 * 3); // 3X size canvas
-  }
+                                                     uint32_t color) {
+  // TO DO
 }
 
-Adafruit_EyeLights_Base::~Adafruit_EyeLights_Base() {
-  delete canvas;
+void Adafruit_EyeLights_Ring_buffered::fill(uint32_t color) {
+  // TO DO
 }
 
-Adafruit_EyeLights::Adafruit_EyeLights(bool withCanvas, uint8_t order)
-    : Adafruit_EyeLights_Base(withCanvas),
-      Adafruit_IS31FL3741_colorGFX(18, 5, order), left_ring(this, false),
-      right_ring(this, true) {}
-
-void Adafruit_EyeLights::drawPixel(int16_t x, int16_t y, uint16_t color) {}
-
-Adafruit_EyeLights_buffered::Adafruit_EyeLights_buffered(bool withCanvas,
-                                                         uint8_t order)
-    : Adafruit_EyeLights_Base(withCanvas),
-      Adafruit_IS31FL3741_colorGFX_buffered(18, 5, order),
-      left_ring(this, false), right_ring(this, true) {}
+void Adafruit_EyeLights::drawPixel(int16_t x, int16_t y, uint16_t color) {
+  // TO DO
+}
 
 void Adafruit_EyeLights_buffered::drawPixel(int16_t x, int16_t y,
-                                            uint16_t color) {}
+                                            uint16_t color) {
+  // TO DO
+}

--- a/Adafruit_IS31FL3741.cpp
+++ b/Adafruit_IS31FL3741.cpp
@@ -659,13 +659,13 @@ void Adafruit_IS31FL3741_QT::drawPixel(int16_t x, int16_t y, uint16_t color) {
     // TO DO: incorporate RGB order here
     int8_t r_off, g_off, b_off;
     if ((col == 12) || (col % 2 == 1)) { // odds + last col
-      b_off = 2;
       r_off = 1;
       g_off = 0;
+      b_off = 2;
     } else { // evens;
-      b_off = 0;
       r_off = 2;
       g_off = 1;
+      b_off = 0;
     }
 
     // Serial.println(offset, HEX);
@@ -733,13 +733,13 @@ void Adafruit_IS31FL3741_QT_buffered::drawPixel(int16_t x, int16_t y,
     // TO DO: incorporate RGB order here
     int8_t r_off, g_off, b_off;
     if ((col == 12) || (col % 2 == 1)) { // odds + last col
-      b_off = 2;
       r_off = 1;
       g_off = 0;
+      b_off = 2;
     } else { // evens;
-      b_off = 0;
       r_off = 2;
       g_off = 1;
+      b_off = 0;
     }
 
     // Serial.println(offset, HEX);
@@ -1292,9 +1292,9 @@ Adafruit_IS31FL3741_GlassesRightRing_buffered::
     @param  ptr      void* pointer to EyeLights object this is attached to.
 */
 /**************************************************************************/
-Adafruit_EyeLights_Ring_Base::Adafruit_EyeLights_Ring_Base(bool isRight,
-                                                           void *ptr)
-    : ring_map(isRight ? right_ring_map : left_ring_map), spex(ptr) {}
+Adafruit_EyeLights_Ring_Base::Adafruit_EyeLights_Ring_Base(void *ptr,
+                                                           bool isRight)
+    : parent(ptr), ring_map(isRight ? right_ring_map : left_ring_map) {}
 
 /**************************************************************************/
 /*!
@@ -1310,10 +1310,10 @@ void Adafruit_EyeLights_Ring::setPixelColor(int16_t n, uint32_t color) {
     g = (((uint16_t)((color >> 8) & 0xFF)) * _brightness) >> 8;
     b = (((uint16_t)(color & 0xFF)) * _brightness) >> 8;
     n *= 3;
-    Adafruit_IS31FL3741 *foo = (Adafruit_IS31FL3741 *)spex;
-    foo->setLEDPWM(pgm_read_word(&ring_map[n]), b);
-    foo->setLEDPWM(pgm_read_word(&ring_map[n + 1]), r);
-    foo->setLEDPWM(pgm_read_word(&ring_map[n + 2]), g);
+    Adafruit_EyeLights *is31 = (Adafruit_EyeLights *)parent;
+    is31->setLEDPWM(pgm_read_word(&ring_map[n]), b);
+    is31->setLEDPWM(pgm_read_word(&ring_map[n + 1]), r);
+    is31->setLEDPWM(pgm_read_word(&ring_map[n + 2]), g);
   }
 }
 
@@ -1340,8 +1340,8 @@ Adafruit_EyeLights_Base::~Adafruit_EyeLights_Base() {
 
 Adafruit_EyeLights::Adafruit_EyeLights(bool withCanvas, uint8_t order)
     : Adafruit_EyeLights_Base(withCanvas),
-      Adafruit_IS31FL3741_colorGFX(18, 5, order), left_ring(false, this),
-      right_ring(true, this) {}
+      Adafruit_IS31FL3741_colorGFX(18, 5, order), left_ring(this, false),
+      right_ring(this, true) {}
 
 void Adafruit_EyeLights::drawPixel(int16_t x, int16_t y, uint16_t color) {}
 
@@ -1349,7 +1349,7 @@ Adafruit_EyeLights_buffered::Adafruit_EyeLights_buffered(bool withCanvas,
                                                          uint8_t order)
     : Adafruit_EyeLights_Base(withCanvas),
       Adafruit_IS31FL3741_colorGFX_buffered(18, 5, order),
-      left_ring(false, this), right_ring(true, this) {}
+      left_ring(this, false), right_ring(this, true) {}
 
 void Adafruit_EyeLights_buffered::drawPixel(int16_t x, int16_t y,
                                             uint16_t color) {}

--- a/Adafruit_IS31FL3741.cpp
+++ b/Adafruit_IS31FL3741.cpp
@@ -231,7 +231,7 @@ bool Adafruit_IS31FL3741::fillTwoPages(uint8_t first_page, uint8_t value) {
     selectPage(first_page + page);           // starting at first_page
     uint8_t addr = 0;    // Writes always start at reg 0 within page
     while (page_bytes) { // While there's data to write for page...
-      uint8_t bytesThisPass = min(page_bytes, 31);
+      uint8_t bytesThisPass = min((int)page_bytes, 31);
       buf[0] = addr;
       if (!_i2c_dev->write(buf, bytesThisPass + 1)) // +1 for addr
         return false;
@@ -440,7 +440,6 @@ bool Adafruit_IS31FL3741_buffered::begin(uint8_t addr, TwoWire *theWire) {
 */
 /**************************************************************************/
 void Adafruit_IS31FL3741_buffered::show(void) {
-  uint16_t total_bytes = 351;
   uint8_t *ptr = ledbuf;
   uint8_t chunk = _i2c_dev->maxBufferSize() - 1;
 

--- a/Adafruit_IS31FL3741.cpp
+++ b/Adafruit_IS31FL3741.cpp
@@ -479,7 +479,7 @@ void Adafruit_IS31FL3741_buffered::show(void) {
 /**************************************************************************/
 Adafruit_IS31FL3741_colorGFX::Adafruit_IS31FL3741_colorGFX(uint8_t width,
                                                            uint8_t height,
-                                                           uint8_t order)
+                                                           IS3741_order order)
     : Adafruit_IS31FL3741(), Adafruit_IS31FL3741_ColorOrder(order),
       Adafruit_GFX(width, height) {}
 
@@ -507,7 +507,7 @@ void Adafruit_IS31FL3741_colorGFX::fill(uint16_t color) {
 */
 /**************************************************************************/
 Adafruit_IS31FL3741_colorGFX_buffered::Adafruit_IS31FL3741_colorGFX_buffered(
-    uint8_t width, uint8_t height, uint8_t order)
+    uint8_t width, uint8_t height, IS3741_order order)
     : Adafruit_IS31FL3741_buffered(), Adafruit_IS31FL3741_ColorOrder(order),
       Adafruit_GFX(width, height) {}
 

--- a/Adafruit_IS31FL3741.h
+++ b/Adafruit_IS31FL3741.h
@@ -254,7 +254,7 @@ public:
     @brief  Constructor for STEMMA QT version (13 x 9 LEDs), direct
             (unbuffered).
   */
-  Adafruit_IS31FL3741_QT(uint8_t order = IS3741_RGB)
+  Adafruit_IS31FL3741_QT(uint8_t order = IS3741_BGR)
       : Adafruit_IS31FL3741_colorGFX(13, 9, order) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 };
@@ -270,7 +270,7 @@ public:
   /*!
     @brief  Constructor for STEMMA QT version (13 x 9 LEDs), buffered.
   */
-  Adafruit_IS31FL3741_QT_buffered(uint8_t order = IS3741_RGB)
+  Adafruit_IS31FL3741_QT_buffered(uint8_t order = IS3741_BGR)
       : Adafruit_IS31FL3741_colorGFX_buffered(13, 9, order) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 };

--- a/Adafruit_IS31FL3741.h
+++ b/Adafruit_IS31FL3741.h
@@ -274,7 +274,7 @@ public:
 /**************************************************************************/
 class Adafruit_EyeLights_Ring_Base {
 public:
-  Adafruit_EyeLights_Ring_Base(bool isRight, void *ptr);
+  Adafruit_EyeLights_Ring_Base(void *ptr, bool isRight);
   /*!
     @brief    Return number of LEDs in ring (a la NeoPixel)
     @returns  int  Always 24.
@@ -291,8 +291,8 @@ public:
 
 protected:
   uint16_t _brightness = 256; ///< Internally 1-256 for math
+  void *parent;               ///< Pointer to EyeLights (or buffered) object
   const uint16_t *ring_map;   ///< Pointer to lookup table
-  void *spex;                 ///< Pointer to glasses object
 };
 
 /**************************************************************************/
@@ -302,8 +302,8 @@ protected:
 /**************************************************************************/
 class Adafruit_EyeLights_Ring : public Adafruit_EyeLights_Ring_Base {
 public:
-  Adafruit_EyeLights_Ring(bool isRight, void *ptr)
-      : Adafruit_EyeLights_Ring_Base(isRight, ptr) {}
+  Adafruit_EyeLights_Ring(void *ptr, bool isRight)
+      : Adafruit_EyeLights_Ring_Base(ptr, isRight) {}
   void setPixelColor(int16_t n, uint32_t color);
   void fill(uint32_t color);
 };
@@ -315,8 +315,8 @@ public:
 /**************************************************************************/
 class Adafruit_EyeLights_Ring_buffered : public Adafruit_EyeLights_Ring_Base {
 public:
-  Adafruit_EyeLights_Ring_buffered(bool isRight, void *ptr)
-      : Adafruit_EyeLights_Ring_Base(isRight, ptr) {}
+  Adafruit_EyeLights_Ring_buffered(void *ptr, bool isRight)
+      : Adafruit_EyeLights_Ring_Base(ptr, isRight) {}
   void setPixelColor(int16_t n, uint32_t color);
   void fill(uint32_t color);
 };

--- a/Adafruit_IS31FL3741.h
+++ b/Adafruit_IS31FL3741.h
@@ -144,7 +144,6 @@ public:
   Adafruit_IS31FL3741_ColorOrder(uint8_t order)
       : rOffset((order >> 4) & 3), gOffset((order >> 2) & 3),
         bOffset(order & 3) {}
-
 protected:
   uint8_t rOffset;
   uint8_t gOffset;
@@ -273,9 +272,9 @@ public:
             eh, it's 3 bytes, even a pointer-to-other-object is bigger.
 */
 /**************************************************************************/
-class Adafruit_EyeLights_Ring_Base : public Adafruit_IS31FL3741_ColorOrder {
+class Adafruit_EyeLights_Ring_Base {
 public:
-  Adafruit_EyeLights_Ring_Base(bool isRight, uint8_t order);
+  Adafruit_EyeLights_Ring_Base(bool isRight, void *ptr);
   /*!
     @brief    Return number of LEDs in ring (a la NeoPixel)
     @returns  int  Always 24.
@@ -293,6 +292,7 @@ public:
 protected:
   uint16_t _brightness = 256; ///< Internally 1-256 for math
   const uint16_t *ring_map;   ///< Pointer to lookup table
+  void *spex;                 ///< Pointer to glasses object
 };
 
 /**************************************************************************/
@@ -302,8 +302,8 @@ protected:
 /**************************************************************************/
 class Adafruit_EyeLights_Ring : public Adafruit_EyeLights_Ring_Base {
 public:
-  Adafruit_EyeLights_Ring(bool isRight, uint8_t order)
-      : Adafruit_EyeLights_Ring_Base(isRight, order) {}
+  Adafruit_EyeLights_Ring(bool isRight, void *ptr)
+      : Adafruit_EyeLights_Ring_Base(isRight, ptr) {}
   void setPixelColor(int16_t n, uint32_t color);
   void fill(uint32_t color);
 };
@@ -315,8 +315,8 @@ public:
 /**************************************************************************/
 class Adafruit_EyeLights_Ring_buffered : public Adafruit_EyeLights_Ring_Base {
 public:
-  Adafruit_EyeLights_Ring_buffered(bool isRight, uint8_t order)
-      : Adafruit_EyeLights_Ring_Base(isRight, order) {}
+  Adafruit_EyeLights_Ring_buffered(bool isRight, void *ptr)
+      : Adafruit_EyeLights_Ring_Base(isRight, ptr) {}
   void setPixelColor(int16_t n, uint32_t color);
   void fill(uint32_t color);
 };
@@ -330,6 +330,7 @@ public:
 class Adafruit_EyeLights_Base {
 public:
   Adafruit_EyeLights_Base(bool withCanvas);
+  ~Adafruit_EyeLights_Base();
   void scale();
   /*!
     @brief    Get pointer to GFX canvas for smooth drawing.
@@ -353,8 +354,6 @@ public:
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   Adafruit_EyeLights_Ring left_ring;
   Adafruit_EyeLights_Ring right_ring;
-
-protected:
 };
 
 /**************************************************************************/

--- a/Adafruit_IS31FL3741.h
+++ b/Adafruit_IS31FL3741.h
@@ -179,6 +179,13 @@ class Adafruit_IS31FL3741_colorGFX : public Adafruit_IS31FL3741,
                                      public Adafruit_IS31FL3741_ColorOrder,
                                      public Adafruit_GFX {
 public:
+  /*!
+    @brief  Constructor for Adafruit_IS31FL3741_colorGFX object. This is
+            used internally by the library, not user code.
+    @param  width   Width, in pixels, passed to GFXcanvas16 constructor.
+    @param  height  Height, in pixels, passed to GFXcanvas16 constructor.
+    @param  order   One of the IS3741_* color types (e.g. IS3741_RGB).
+  */
   Adafruit_IS31FL3741_colorGFX(uint8_t width, uint8_t height,
                                IS3741_order order);
   // Overload the base (monochrome) fill() with a GFX RGB565-style color.
@@ -199,6 +206,13 @@ class Adafruit_IS31FL3741_colorGFX_buffered
       public Adafruit_IS31FL3741_ColorOrder,
       public Adafruit_GFX {
 public:
+  /*!
+    @brief  Constructor for Adafruit_IS31FL3741_colorGFX_buffered object.
+            This is used internally by the library, not user code.
+    @param  width   Width, in pixels, passed to GFXcanvas16 constructor.
+    @param  height  Height, in pixels, passed to GFXcanvas16 constructor.
+    @param  order   One of the IS3741_* color types (e.g. IS3741_RGB).
+  */
   Adafruit_IS31FL3741_colorGFX_buffered(uint8_t width, uint8_t height,
                                         IS3741_order order);
   // Overload the base (monochrome) fill() with a GFX RGB565-style color.
@@ -232,6 +246,8 @@ public:
   /*!
     @brief  Constructor for Lumissil IS31FL3741 OEM evaluation board,
             13x9 pixels, direct (unbuffered).
+    @param  order  One of the IS3741_order enumeration types for RGB
+                   sequence. Default is IS3741_BGR.
   */
   Adafruit_IS31FL3741_EVB(IS3741_order order = IS3741_BGR)
       : Adafruit_IS31FL3741_colorGFX(9, 13, order) {}
@@ -249,6 +265,8 @@ public:
   /*!
     @brief  Constructor for Lumissil IS31FL3741 OEM evaluation board,
             13x9 pixels, buffered.
+    @param  order  One of the IS3741_order enumeration types for RGB
+                   sequence. Default is IS3741_BGR.
   */
   Adafruit_IS31FL3741_EVB_buffered(IS3741_order order = IS3741_BGR)
       : Adafruit_IS31FL3741_colorGFX_buffered(9, 13, order) {}
@@ -266,6 +284,8 @@ public:
   /*!
     @brief  Constructor for STEMMA QT version (13 x 9 LEDs), direct
             (unbuffered).
+    @param  order  One of the IS3741_order enumeration types for RGB
+                   sequence. Default is IS3741_BGR.
   */
   Adafruit_IS31FL3741_QT(IS3741_order order = IS3741_BGR)
       : Adafruit_IS31FL3741_colorGFX(13, 9, order) {}
@@ -282,6 +302,8 @@ class Adafruit_IS31FL3741_QT_buffered
 public:
   /*!
     @brief  Constructor for STEMMA QT version (13 x 9 LEDs), buffered.
+    @param  order  One of the IS3741_order enumeration types for RGB
+                   sequence. Default is IS3741_BGR.
   */
   Adafruit_IS31FL3741_QT_buffered(IS3741_order order = IS3741_BGR)
       : Adafruit_IS31FL3741_colorGFX_buffered(13, 9, order) {}
@@ -333,6 +355,12 @@ protected:
 /**************************************************************************/
 class Adafruit_EyeLights_Ring : public Adafruit_EyeLights_Ring_Base {
 public:
+  /*!
+    @brief  Constructor for one of the EyeLights ring objects (direct,
+            unbuffered). Used internally by the library, not user code.
+    @param  parent   Pointer to parent Adafruit_EyeLights object.
+    @param  isRight  true = right ring, false = left ring.
+  */
   Adafruit_EyeLights_Ring(void *parent, bool isRight)
       : Adafruit_EyeLights_Ring_Base(parent, isRight) {}
   void setPixelColor(int16_t n, uint32_t color);
@@ -346,6 +374,12 @@ public:
 /**************************************************************************/
 class Adafruit_EyeLights_Ring_buffered : public Adafruit_EyeLights_Ring_Base {
 public:
+  /*!
+    @brief  Constructor for one of the EyeLights ring objects (buffered).
+            Used internally by the library, not user code.
+    @param  parent   Pointer to parent Adafruit_EyeLights_buffered object.
+    @param  isRight  true = right ring, false = left ring.
+  */
   Adafruit_EyeLights_Ring_buffered(void *parent, bool isRight)
       : Adafruit_EyeLights_Ring_Base(parent, isRight) {}
   void setPixelColor(int16_t n, uint32_t color);
@@ -360,6 +394,13 @@ public:
 /**************************************************************************/
 class Adafruit_EyeLights_Base {
 public:
+  /*!
+    @brief  Constructor for Adafruit_EyeLights_Base object. This is used
+            internally by the library, not user code.
+    @param  withCanvas  true to also allocate a 3X size GFXcanvas16 object
+                        (can be used for antialiasing via the smooth()
+                        function), false for normal direct-to-matrix drawing.
+  */
   Adafruit_EyeLights_Base(bool withCanvas) {
     if (withCanvas)
       canvas = new GFXcanvas16(18 * 3, 5 * 3);
@@ -382,14 +423,23 @@ protected:
 class Adafruit_EyeLights : public Adafruit_EyeLights_Base,
                            public Adafruit_IS31FL3741_colorGFX {
 public:
+  /*!
+    @brief  Constructor for Adafruit_EyeLights object.
+    @param  withCanvas  true to also allocate a 3X size GFXcanvas16 object
+                        (can be used for antialiasing via the smooth()
+                        function), false for normal direct-to-matrix
+                        drawing. Default is false.
+    @param  order       One of the IS3741_order enumeration types for RGB
+                        sequence. Default is IS3741_BGR.
+  */
   Adafruit_EyeLights(bool withCanvas = false, IS3741_order order = IS3741_BGR)
       : Adafruit_EyeLights_Base(withCanvas),
         Adafruit_IS31FL3741_colorGFX(18, 5, order), left_ring(this, false),
         right_ring(this, true) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   void scale();
-  Adafruit_EyeLights_Ring left_ring;
-  Adafruit_EyeLights_Ring right_ring;
+  Adafruit_EyeLights_Ring left_ring;  ///< Left LED ring object
+  Adafruit_EyeLights_Ring right_ring; ///< Right LED ring object
 };
 
 /**************************************************************************/
@@ -401,6 +451,15 @@ class Adafruit_EyeLights_buffered
     : public Adafruit_EyeLights_Base,
       public Adafruit_IS31FL3741_colorGFX_buffered {
 public:
+  /*!
+    @brief  Constructor for Adafruit_EyeLights_buffered object.
+    @param  withCanvas  true to also allocate a 3X size GFXcanvas16 object
+                        (can be used for antialiasing via the smooth()
+                        function), false for normal direct-to-matrix
+                        drawing. Default is false.
+    @param  order       One of the IS3741_order enumeration types for RGB
+                        sequence. Default is IS3741_BGR.
+  */
   Adafruit_EyeLights_buffered(bool withCanvas = false,
                               IS3741_order order = IS3741_BGR)
       : Adafruit_EyeLights_Base(withCanvas),
@@ -408,8 +467,8 @@ public:
         left_ring(this, false), right_ring(this, true) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   void scale();
-  Adafruit_EyeLights_Ring_buffered left_ring;
-  Adafruit_EyeLights_Ring_buffered right_ring;
+  Adafruit_EyeLights_Ring_buffered left_ring;  ///< Left LED ring object
+  Adafruit_EyeLights_Ring_buffered right_ring; ///< Right LED ring object
 };
 
 /* =======================================================================

--- a/Adafruit_IS31FL3741.h
+++ b/Adafruit_IS31FL3741.h
@@ -329,13 +329,11 @@ public:
       canvas = new GFXcanvas16(18 * 3, 5 * 3);
   }
   ~Adafruit_EyeLights_Base() { delete canvas; }
-  void scale();
   /*!
     @brief    Get pointer to GFX canvas for smooth drawing.
     @returns  GFXcanvas16*  Pointer to GFXcanvas16 object, or NULL.
   */
   GFXcanvas16 *getCanvas(void) const { return canvas; }
-
 protected:
   GFXcanvas16 *canvas = NULL; ///< Pointer to GFX canvas
 };
@@ -353,6 +351,7 @@ public:
         Adafruit_IS31FL3741_colorGFX(18, 5, order), left_ring(this, false),
         right_ring(this, true) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
+  void scale();
   Adafruit_EyeLights_Ring left_ring;
   Adafruit_EyeLights_Ring right_ring;
 };
@@ -372,12 +371,13 @@ public:
         Adafruit_IS31FL3741_colorGFX_buffered(18, 5, order),
         left_ring(this, false), right_ring(this, true) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
+  void scale();
   Adafruit_EyeLights_Ring_buffered left_ring;
   Adafruit_EyeLights_Ring_buffered right_ring;
 };
 
 /* =======================================================================
-   This is the older (maybe deprecated) way of using Adafruit EyeLights.
+   This is the older (likely deprecated) way of using Adafruit EyeLights.
    It requires a few extra steps of the user for object declarations, and
    doesn't handle different RGB color orders.
    =======================================================================*/
@@ -385,6 +385,8 @@ public:
 /**************************************************************************/
 /*!
     @brief  Class for Adafruit LED Glasses (matrix portion).
+    @note   This class is deprecated but provided for compatibility.
+            New code should use the Adafruit_EyeLights classes.
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesMatrix : public Adafruit_GFX {
@@ -401,6 +403,8 @@ protected:
     @brief  Class for Adafruit LED Glasses (ring portion). Not used by user
             code directly, the left and right classes below create distinct
             subclasses for that.
+    @note   This class is deprecated but provided for compatibility.
+            New code should use the Adafruit_EyeLights classes.
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesRing {
@@ -432,6 +436,8 @@ protected:
 /**************************************************************************/
 /*!
     @brief  Class for Adafruit LED Glasses (left ring).
+    @note   This class is deprecated but provided for compatibility.
+            New code should use the Adafruit_EyeLights classes.
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesLeftRing
@@ -443,6 +449,8 @@ public:
 /**************************************************************************/
 /*!
     @brief  Class for Adafruit LED Glasses (right ring).
+    @note   This class is deprecated but provided for compatibility.
+            New code should use the Adafruit_EyeLights classes.
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesRightRing
@@ -456,6 +464,8 @@ public:
     @brief  Class for Adafruit LED Glasses (matrix portion) with LED data
             being buffered on the microcontroller and sent only when show()
             is called.
+    @note   This class is deprecated but provided for compatibility.
+            New code should use the Adafruit_EyeLights classes.
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesMatrix_buffered : public Adafruit_GFX {
@@ -481,6 +491,8 @@ protected:
             being buffered on the microcontroller and sent only when show()
             is called. Not used by user code directly, the left and right
             classes below create distinct subclasses for that.
+    @note   This class is deprecated but provided for compatibility.
+            New code should use the Adafruit_EyeLights classes.
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesRing_buffered {
@@ -514,6 +526,8 @@ protected:
     @brief  Class for Lumissil IS31FL3741 Glasses (left ring) with LED
             data being buffered on the microcontroller and sent only when
             show() is called.
+    @note   This class is deprecated but provided for compatibility.
+            New code should use the Adafruit_EyeLights classes.
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesLeftRing_buffered
@@ -528,6 +542,8 @@ public:
     @brief  Class for Adafruit LED Glasses (right ring) with LED data being
             buffered on the microcontroller and sent only when show() is
             called.
+    @note   This class is deprecated but provided for compatibility.
+            New code should use the Adafruit_EyeLights classes.
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesRightRing_buffered

--- a/Adafruit_IS31FL3741.h
+++ b/Adafruit_IS31FL3741.h
@@ -19,13 +19,15 @@
 #define IS3741_FUNCREG_RESET 0x3F
 
 // RGB pixel color order permutations
-// Offset:           R          G          B
-#define IS3741_RGB ((0 << 4) | (1 << 2) | (2)) ///< Encode as R,G,B
-#define IS3741_RBG ((0 << 4) | (2 << 2) | (1)) ///< Encode as R,B,G
-#define IS3741_GRB ((1 << 4) | (0 << 2) | (2)) ///< Encode as G,R,B
-#define IS3741_GBR ((2 << 4) | (0 << 2) | (1)) ///< Encode as G,B,R
-#define IS3741_BRG ((1 << 4) | (2 << 2) | (0)) ///< Encode as B,R,G
-#define IS3741_BGR ((2 << 4) | (1 << 2) | (0)) ///< Encode as B,G,R
+typedef enum {
+  // Offset:     R          G          B
+  IS3741_RGB = ((0 << 4) | (1 << 2) | (2)), // Encode as R,G,B
+  IS3741_RBG = ((0 << 4) | (2 << 2) | (1)), // Encode as R,B,G
+  IS3741_GRB = ((1 << 4) | (0 << 2) | (2)), // Encode as G,R,B
+  IS3741_GBR = ((2 << 4) | (0 << 2) | (1)), // Encode as G,B,R
+  IS3741_BRG = ((1 << 4) | (2 << 2) | (0)), // Encode as B,R,G
+  IS3741_BGR = ((2 << 4) | (1 << 2) | (0)), // Encode as B,G,R
+} IS3741_order;
 
 // BASE IS31 CLASSES -------------------------------------------------------
 
@@ -143,9 +145,9 @@ class Adafruit_IS31FL3741_ColorOrder {
 public:
   /*!
     @brief  Constructor for Adafruit_IS31FL3741_ColorOrder
-    @param  order  One of the IS3741_* color defined (e.g. IS3741_RGB).
+    @param  order  One of the IS3741_* color types (e.g. IS3741_RGB).
   */
-  Adafruit_IS31FL3741_ColorOrder(uint8_t order)
+  Adafruit_IS31FL3741_ColorOrder(IS3741_order order)
       : rOffset((order >> 4) & 3), gOffset((order >> 2) & 3),
         bOffset(order & 3) {}
   uint8_t rOffset; ///< Index of red element within RGB triplet
@@ -167,7 +169,8 @@ class Adafruit_IS31FL3741_colorGFX : public Adafruit_IS31FL3741,
                                      public Adafruit_IS31FL3741_ColorOrder,
                                      public Adafruit_GFX {
 public:
-  Adafruit_IS31FL3741_colorGFX(uint8_t width, uint8_t height, uint8_t order);
+  Adafruit_IS31FL3741_colorGFX(uint8_t width, uint8_t height,
+                               IS3741_order order);
   // Overload the base (monochrome) fill() with a GFX RGB565-style color.
   void fill(uint16_t color = 0);
 };
@@ -187,7 +190,7 @@ class Adafruit_IS31FL3741_colorGFX_buffered
       public Adafruit_GFX {
 public:
   Adafruit_IS31FL3741_colorGFX_buffered(uint8_t width, uint8_t height,
-                                        uint8_t order);
+                                        IS3741_order order);
   // Overload the base (monochrome) fill() with a GFX RGB565-style color.
   void fill(uint16_t color = 0);
 };
@@ -220,7 +223,7 @@ public:
     @brief  Constructor for Lumissil IS31FL3741 OEM evaluation board,
             13x9 pixels, direct (unbuffered).
   */
-  Adafruit_IS31FL3741_EVB(uint8_t order = IS3741_BGR)
+  Adafruit_IS31FL3741_EVB(IS3741_order order = IS3741_BGR)
       : Adafruit_IS31FL3741_colorGFX(9, 13, order) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 };
@@ -237,7 +240,7 @@ public:
     @brief  Constructor for Lumissil IS31FL3741 OEM evaluation board,
             13x9 pixels, buffered.
   */
-  Adafruit_IS31FL3741_EVB_buffered(uint8_t order = IS3741_BGR)
+  Adafruit_IS31FL3741_EVB_buffered(IS3741_order order = IS3741_BGR)
       : Adafruit_IS31FL3741_colorGFX_buffered(9, 13, order) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 };
@@ -254,7 +257,7 @@ public:
     @brief  Constructor for STEMMA QT version (13 x 9 LEDs), direct
             (unbuffered).
   */
-  Adafruit_IS31FL3741_QT(uint8_t order = IS3741_BGR)
+  Adafruit_IS31FL3741_QT(IS3741_order order = IS3741_BGR)
       : Adafruit_IS31FL3741_colorGFX(13, 9, order) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 };
@@ -270,7 +273,7 @@ public:
   /*!
     @brief  Constructor for STEMMA QT version (13 x 9 LEDs), buffered.
   */
-  Adafruit_IS31FL3741_QT_buffered(uint8_t order = IS3741_BGR)
+  Adafruit_IS31FL3741_QT_buffered(IS3741_order order = IS3741_BGR)
       : Adafruit_IS31FL3741_colorGFX_buffered(13, 9, order) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 };
@@ -370,7 +373,7 @@ protected:
 class Adafruit_EyeLights : public Adafruit_EyeLights_Base,
                            public Adafruit_IS31FL3741_colorGFX {
 public:
-  Adafruit_EyeLights(bool withCanvas = false, uint8_t order = IS3741_BGR)
+  Adafruit_EyeLights(bool withCanvas = false, IS3741_order order = IS3741_BGR)
       : Adafruit_EyeLights_Base(withCanvas),
         Adafruit_IS31FL3741_colorGFX(18, 5, order), left_ring(this, false),
         right_ring(this, true) {}
@@ -390,7 +393,7 @@ class Adafruit_EyeLights_buffered
       public Adafruit_IS31FL3741_colorGFX_buffered {
 public:
   Adafruit_EyeLights_buffered(bool withCanvas = false,
-                              uint8_t order = IS3741_BGR)
+                              IS3741_order order = IS3741_BGR)
       : Adafruit_EyeLights_Base(withCanvas),
         Adafruit_IS31FL3741_colorGFX_buffered(18, 5, order),
         left_ring(this, false), right_ring(this, true) {}

--- a/Adafruit_IS31FL3741.h
+++ b/Adafruit_IS31FL3741.h
@@ -18,14 +18,30 @@
 #define IS3741_FUNCREG_GCURRENT 0x01
 #define IS3741_FUNCREG_RESET 0x3F
 
+// RGB pixel color order permutations
+// Offset:           R          G          B
+#define IS3741_RGB ((0 << 4) | (1 << 2) | (2)) ///< Encode as R,G,B
+#define IS3741_RBG ((0 << 4) | (2 << 2) | (1)) ///< Encode as R,B,G
+#define IS3741_GRB ((1 << 4) | (0 << 2) | (2)) ///< Encode as G,R,B
+#define IS3741_GBR ((2 << 4) | (0 << 2) | (1)) ///< Encode as G,B,R
+#define IS3741_BRG ((1 << 4) | (2 << 2) | (0)) ///< Encode as B,R,G
+#define IS3741_BGR ((2 << 4) | (1 << 2) | (0)) ///< Encode as B,G,R
+
 /**************************************************************************/
 /*!
-    @brief Class for generic IS31FL3741 breakout.
+    @brief  Class for Lumissil IS31FL3741 LED driver. This is the base class
+            upon which the rest of this code builds. It focuses on lowest-
+            level I2C operations and the chip registers, and has no concept
+            of a 2D graphics coordinate system, nor of RGB colors. It is
+            linear and monochromatic.
 */
 /**************************************************************************/
-class Adafruit_IS31FL3741 : public Adafruit_GFX {
+class Adafruit_IS31FL3741 {
 public:
-  Adafruit_IS31FL3741(uint8_t x = 9, uint8_t y = 13);
+  /*!
+    @brief Constructor for IS31FL3741 LED driver.
+  */
+  Adafruit_IS31FL3741() {}
   bool begin(uint8_t addr = IS3741_ADDR_DEFAULT, TwoWire *theWire = &Wire);
   bool reset(void);
   bool enable(bool en);
@@ -41,27 +57,34 @@ public:
   bool setLEDPWM(uint16_t lednum, uint8_t pwm);
   bool fill(uint8_t fillpwm = 0);
 
-  void drawPixel(int16_t x, int16_t y, uint16_t color);
+  // Although Adafruit_IS31FL3741 itself has no concept of color, most of
+  // its subclasses do. These color-related operations go here so that all
+  // subclasses have access. Any 'packed' 24-bit colors received or returned
+  // by these functions are always in 0xRRGGBB order; RGB reordering for
+  // different devices takes place elsewhere, in subclasses.
+
   /*!
-    @brief Converter for RGB888-format color to RGB565-format
-    @param red 8-bit red color
-    @param green 8-bit green color
-    @param blue 8-bit blue color
-    @returns Packed 16-bit RGB565 color
-    @note  Yes, the name is unfortunate -- have lowercase color565() here,
-           and uppercase ColorHSV() later. This is for compatibility with
-           existing code from Adafruit_GFX and Adafruit_NeoPixel, which
-           were separately developed and used differing cases. The idea
-           here is to help re-use existing GFX code, so don't "fix."
+    @brief    Converter for RGB888-format color (separate) to RGB565-format
+    @param    red    8-bit red value.
+    @param    green  8-bit green value.
+    @param    blue   8-bit blue value.
+    @returns  Packed 16-bit RGB565 color.
+    @note     Yes, the name is unfortunate -- have lowercase color565()
+              here, and uppercase ColorHSV() later. This is for
+              compatibility with existing code from Adafruit_GFX and
+              Adafruit_NeoPixel, which were separately developed and used
+              differing cases. The idea here is to help re-use existing
+              Arduino sketch code from other projects, so don't "fix" this.
   */
   static uint16_t color565(uint8_t red, uint8_t green, uint8_t blue) {
     return ((red & 0xF8) << 8) | ((green & 0xFC) << 3) | (blue >> 3);
   };
+
   /*!
-    @brief Converter for RGB888-format color (packed) to RGB565-format
-    @param color 24-bit value (0x00RRGGBB)
-    @returns Packed 16-bit RGB565 color (0bRRRRRGGGGGGBBBBB)
-    @note    See notes above re: naming.
+    @brief    Converter for RGB888-format color (packed) to RGB565-format.
+    @param    color  24-bit value (0x00RRGGBB)
+    @returns  Packed 16-bit RGB565 color (0bRRRRRGGGGGGBBBBB)
+    @note     See notes above re: naming.
   */
   static uint16_t color565(uint32_t color) {
     return ((color >> 8) & 0xF800) | ((color >> 5) & 0x07E0) |
@@ -72,37 +95,279 @@ public:
 
 protected:
   bool selectPage(uint8_t page);
+  bool setLEDvalue(uint8_t first_page, uint16_t lednum, uint8_t value);
+  bool fillTwoPages(uint8_t first_page, uint8_t value);
 
   int8_t _page = -1; ///< Cached value of the page we're currently addressing
-
   Adafruit_I2CDevice *_i2c_dev = NULL; ///< Pointer to I2C device
 };
 
 /**************************************************************************/
 /*!
-    @brief Class for Lumissil IS31FL3741 EVB.
+    @brief  Class for a "buffered" Lumissil IS31FL3741 LED driver -- LED PWM
+            state is staged in RAM (requiring 352 extra bytes vs base class)
+            and sent to device only when show() is called. Otherwise
+            functionally identical. LED scaling values (vs PWM) are NOT
+            staged in RAM and are issued individually as normal; scaling is
+            infrequently used and not worth the extra memory it would incur.
 */
 /**************************************************************************/
-class Adafruit_IS31FL3741_EVB : public Adafruit_IS31FL3741 {
+class Adafruit_IS31FL3741_buffered : public Adafruit_IS31FL3741 {
 public:
-  Adafruit_IS31FL3741_EVB(void);
+  Adafruit_IS31FL3741_buffered();
+  bool begin(uint8_t addr = IS3741_ADDR_DEFAULT, TwoWire *theWire = &Wire);
+  void show(void); // DON'T const this
+  /*!
+    @brief    Return address of LED buffer.
+    @returns  uint8_t*  Pointer to first LED position in buffer.
+  */
+  uint8_t *getBuffer(void) { return &ledbuf[1]; }; // See notes in show()
+protected:
+  uint8_t ledbuf[352]; ///< LEDs in RAM. +1 byte is intentional, see show()
+};
+
+/**************************************************************************/
+/*!
+    @brief  Class for specifying RGB byte sequence order when above classes
+            are used with RGB LEDs. Not used on its own...other subclasses
+            of Adafruit_IS31FL3741 (direct or buffered) may reference this
+            (alongside Adafruit_GFX) via multiple inheritance. It's mostly
+            so the same code isn't needed repeatedly later.
+*/
+/**************************************************************************/
+class Adafruit_IS31FL3741_ColorOrder {
+public:
+  /*!
+    @brief  Constructor for Adafruit_IS31FL3741_ColorOrder
+    @param  order  One of the IS3741_* color defined (e.g. IS3741_RGB).
+  */
+  Adafruit_IS31FL3741_ColorOrder(uint8_t order)
+      : rOffset((order >> 4) & 3), gOffset((order >> 2) & 3),
+        bOffset(order & 3) {}
+
+//protected:
+  uint8_t rOffset;
+  uint8_t gOffset;
+  uint8_t bOffset;
+};
+
+/**************************************************************************/
+/*!
+    @brief  Class encapsulating a direct (unbuffered) IS31FL3741, ColorOrder
+            and GFX all in one -- mostly so a common fill() function can be
+            provided for all subclassed objects instead of repeated
+            implementations. Other functions like drawPixel() are still
+            unique per subclass. Not used on its own, other direct
+            (unbuffered) subclasses reference this.
+*/
+/**************************************************************************/
+class Adafruit_IS31FL3741_colorGFX : public Adafruit_IS31FL3741,
+                                     public Adafruit_IS31FL3741_ColorOrder,
+                                     public Adafruit_GFX {
+public:
+  Adafruit_IS31FL3741_colorGFX(uint8_t width, uint8_t height, uint8_t order);
+  // Overload the base (monochrome) fill() with a GFX RGB565-style color.
+  void fill(uint16_t color = 0);
+};
+
+/**************************************************************************/
+/*!
+    @brief  Class encapsulating a buffered IS31FL3741, ColorOrder and GFX
+            all in one -- mostly so a common fill() function can be provided
+            for all subclassed objects instead of repeated implementations.
+            Other functions like drawPixel() are still unique per subclass.
+            Not used on its own, other buffered subclasses reference this.
+*/
+/**************************************************************************/
+class Adafruit_IS31FL3741_colorGFX_buffered
+    : public Adafruit_IS31FL3741_buffered,
+      public Adafruit_IS31FL3741_ColorOrder,
+      public Adafruit_GFX {
+public:
+  Adafruit_IS31FL3741_colorGFX_buffered(uint8_t width, uint8_t height,
+                                        uint8_t order);
+  // Overload the base (monochrome) fill() with a GFX RGB565-style color.
+  void fill(uint16_t color = 0);
+};
+
+/* =======================================================================
+   So, IN PRINCIPLE, additional classes Adafruit_IS31FL3741_monoGFX and
+   Adafruit_IS31FL3741_monoGFX_buffered could go here for hypothetical
+   single-color "grayscale" matrices -- they'd be similar to the two
+   colorGFX classes above, but without inheriting ColorOrder. Since no
+   actual hardware along such lines currently exists, they are not
+   implemented, but this is where they'd be. I've got deadlines.
+
+   Now we'll build on the classes above to create specific LED board
+   varieties. These "complete" items are then instantiated in user code.
+   There are two of each -- a direct (unbuffered) and buffered version.
+   It's done this way (rather than a single class with a buffer flag) to
+   avoid malloc() -- object & buffer just go on heap or stack as needed.
+   =======================================================================*/
+
+/**************************************************************************/
+/*!
+    @brief  Class for Lumissil IS31FL3741 OEM evaluation board, direct
+            (unbuffered).
+*/
+/**************************************************************************/
+class Adafruit_IS31FL3741_EVB : public Adafruit_IS31FL3741_colorGFX {
+public:
+  Adafruit_IS31FL3741_EVB(uint8_t order = IS3741_RGB);
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 };
 
 /**************************************************************************/
 /*!
-    @brief Class for Lumissil IS31FL3741 QT.
+    @brief  Class for Lumissil IS31FL3741 OEM evaluation board, buffered.
 */
 /**************************************************************************/
-class Adafruit_IS31FL3741_QT : public Adafruit_IS31FL3741 {
+class Adafruit_IS31FL3741_EVB_buffered
+    : public Adafruit_IS31FL3741_colorGFX_buffered {
 public:
-  Adafruit_IS31FL3741_QT(void);
+  Adafruit_IS31FL3741_EVB_buffered(uint8_t order = IS3741_RGB);
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 };
 
 /**************************************************************************/
 /*!
-    @brief Class for Lumissil IS31FL3741 Glasses (matrix portion).
+    @brief  Class for IS31FL3741 Adafruit STEMMA QT board, direct
+            (unbuffered).
+*/
+/**************************************************************************/
+class Adafruit_IS31FL3741_QT : public Adafruit_IS31FL3741_colorGFX {
+public:
+  Adafruit_IS31FL3741_QT(uint8_t order = IS3741_RGB);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+};
+
+/**************************************************************************/
+/*!
+    @brief  Class for IS31FL3741 Adafruit STEMMA QT board, buffered.
+*/
+/**************************************************************************/
+class Adafruit_IS31FL3741_QT_buffered
+    : public Adafruit_IS31FL3741_colorGFX_buffered {
+public:
+  Adafruit_IS31FL3741_QT_buffered(uint8_t order = IS3741_RGB);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+};
+
+/* =======================================================================
+   This is the newer and simpler way (to the user) of using Adafruit
+   EyeLights LED glasses. Declaring an object (direct or buffered) gets
+   you the matrix and rings automatically; no need to instantiate as
+   separate objects, nor does one need to explicitly declare a base
+   Adafruit_IS31FL3741 object. Internally the code has a few more layers
+   but the user doesn't need to see that.
+   =======================================================================*/
+
+/**************************************************************************/
+/*!
+    @brief  Base class for EyeLights LED ring. Holds a few items that are
+            common to direct or buffered instances, left or right ring.
+*/
+/**************************************************************************/
+class Adafruit_EyeLights_Ring_Base : public Adafruit_IS31FL3741_ColorOrder {
+public:
+  Adafruit_EyeLights_Ring_Base(bool isRight, uint8_t order);
+  /*!
+    @brief    Return number of LEDs in ring (a la NeoPixel)
+    @returns  int  Always 24.
+  */
+  uint8_t numPixels(void) const { return 24; }
+  /*!
+    @brief  Set brightness of LED ring. This is a mathematical brightness
+            scale applied to setPixel() colors when setting ring pixels,
+            distinct from any value passed to setLEDscaling() functions,
+            because matrix and rings share pixels.
+    @param  b  Brightness from 0 (off) to 255 (max).
+  */
+  void setBrightness(uint8_t b) { _brightness = b + 1; }
+protected:
+  uint16_t _brightness = 256; ///< Internally 1-256 for math
+  const uint16_t *ring_map;   ///< Pointer to lookup table
+};
+
+/**************************************************************************/
+/*!
+    @brief  Class for direct (unbuffered) EyeLights LED ring, left or right.
+*/
+/**************************************************************************/
+class Adafruit_EyeLights_Ring : public Adafruit_EyeLights_Ring_Base {
+public:
+  Adafruit_EyeLights_Ring(bool isRight, uint8_t order) : Adafruit_EyeLights_Ring_Base(isRight, order) {}
+  void setPixelColor(int16_t n, uint32_t color);
+  void fill(uint32_t color);
+};
+
+/**************************************************************************/
+/*!
+    @brief  Class for buffered EyeLights LED ring, left or right.
+*/
+/**************************************************************************/
+class Adafruit_EyeLights_Ring_buffered : public Adafruit_EyeLights_Ring_Base {
+public:
+  Adafruit_EyeLights_Ring_buffered(bool isRight, uint8_t order) : Adafruit_EyeLights_Ring_Base(isRight, order) {}
+  void setPixelColor(int16_t n, uint32_t color);
+  void fill(uint32_t color);
+};
+
+/**************************************************************************/
+/*!
+    @brief  Base class for EyeLights LED glasses. Holds a few items that
+            are common to direct or buffered instances.
+*/
+/**************************************************************************/
+class Adafruit_EyeLights_Base {
+public:
+  Adafruit_EyeLights_Base(bool withCanvas);
+  void scale();
+  /*!
+    @brief    Get pointer to GFX canvas for smooth drawing.
+    @returns  GFXcanvas16*  Pointer to GFXcanvas16 object, or NULL.
+  */
+  GFXcanvas16 *getCanvas(void) const { return canvas; };
+protected:
+  GFXcanvas16 *canvas = NULL; ///< Pointer to GFX canvas
+};
+
+/**************************************************************************/
+/*!
+    @brief  Class for Adafruit EyeLights, direct (unbuffered).
+*/
+/**************************************************************************/
+class Adafruit_EyeLights : public Adafruit_EyeLights_Base, public Adafruit_IS31FL3741_colorGFX {
+public:
+  Adafruit_EyeLights(bool withCanvas = false, uint8_t order = IS3741_RGB);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+  Adafruit_EyeLights_Ring left_ring;
+  Adafruit_EyeLights_Ring right_ring;
+protected:
+};
+
+/**************************************************************************/
+/*!
+    @brief  Class for Adafruit EyeLights, buffered.
+*/
+/**************************************************************************/
+class Adafruit_EyeLights_buffered : public Adafruit_EyeLights_Base, public Adafruit_IS31FL3741_colorGFX_buffered {
+public:
+  Adafruit_EyeLights_buffered(bool withCanvas = false, uint8_t order = IS3741_RGB);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+  Adafruit_EyeLights_Ring_buffered left_ring;
+  Adafruit_EyeLights_Ring_buffered right_ring;
+};
+
+
+/* =======================================================================
+   This is the older and maybe deprecated way of using Adafruit EyeLights.
+   It requires a few extra steps of the user for object declarations.
+   =======================================================================*/
+
+/**************************************************************************/
+/*!
+    @brief  Class for Adafruit LED Glasses (matrix portion).
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesMatrix : public Adafruit_GFX {
@@ -116,9 +381,9 @@ protected:
 
 /**************************************************************************/
 /*!
-    @brief Class for Lumissil IS31FL3741 Glasses (ring portion).
-           Not used by user code directly, the left and right classes
-           below create distinct subclasses for that.
+    @brief  Class for Adafruit LED Glasses (ring portion). Not used by user
+            code directly, the left and right classes below create distinct
+            subclasses for that.
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesRing {
@@ -149,7 +414,7 @@ protected:
 
 /**************************************************************************/
 /*!
-    @brief Class for Lumissil IS31FL3741 Glasses (left ring).
+    @brief  Class for Adafruit LED Glasses (left ring).
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesLeftRing
@@ -160,7 +425,7 @@ public:
 
 /**************************************************************************/
 /*!
-    @brief Class for Lumissil IS31FL3741 Glasses (right ring).
+    @brief Class for Adafruit LED Glasses (right ring).
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesRightRing
@@ -171,53 +436,9 @@ public:
 
 /**************************************************************************/
 /*!
-    @brief Class for Lumissil IS31FL3741 Glasses with LED data being
-           buffered on the microcontroller and sent only when show() is
-           called.
-*/
-/**************************************************************************/
-class Adafruit_IS31FL3741_buffered : public Adafruit_IS31FL3741 {
-public:
-  Adafruit_IS31FL3741_buffered(uint8_t x = 9, uint8_t y = 13);
-  ~Adafruit_IS31FL3741_buffered(void);
-  bool begin(uint8_t addr = IS3741_ADDR_DEFAULT, TwoWire *theWire = &Wire);
-  /*!
-    @brief Don't use this drawPixel(), it's only required because
-           Adafruit_IS31FL3741 is a subclass of GFX which declared a
-           virtual function. Use the Adafruit_GlassesMatrix_buffered
-           class for drawing.
-    @param x     Ignored
-    @param y     Ignored
-    @param color Ignored
-  */
-  void drawPixel(int16_t x, int16_t y, uint16_t color) const {};
-  void show(void); // DON'T const this
-  /*!
-    @brief    Return address of LED buffer.
-    @returns  uint8_t*  Pointer to first LED position in buffer.
-  */
-  uint8_t *getBuffer(void) { return &ledbuf[1]; }; // See notes in show()
-protected:
-  uint8_t ledbuf[352]; ///< LEDs in RAM. +1 byte is intentional, see show()
-};
-
-/**************************************************************************/
-/*!
-    @brief Class for Lumissil IS31FL3741 QT (buffered).
-*/
-/**************************************************************************/
-class Adafruit_IS31FL3741_QT_buffered : public Adafruit_IS31FL3741_buffered {
-public:
-  Adafruit_IS31FL3741_QT_buffered(void);
-  void drawPixel(int16_t x, int16_t y, uint16_t color);
-  void fill(uint16_t color);
-};
-
-/**************************************************************************/
-/*!
-    @brief Class for Lumissil IS31FL3741 Glasses (matrix portion) with LED
-           data being buffered on the microcontroller and sent only when
-           show() is called.
+    @brief  Class for Adafruit LED Glasses (matrix portion) with LED data
+            being buffered on the microcontroller and sent only when show()
+            is called.
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesMatrix_buffered : public Adafruit_GFX {
@@ -239,10 +460,10 @@ protected:
 
 /**************************************************************************/
 /*!
-    @brief Class for Lumissil IS31FL3741 Glasses (ring portion) with LED
-           data being buffered on the microcontroller and sent only when
-           show() is called. Not used by user code directly, the left and
-           right classes below create distinct subclasses for that.
+    @brief  Class for Adafruit LED Glasses (ring portion) with LED data
+            being buffered on the microcontroller and sent only when show()
+            is called. Not used by user code directly, the left and right
+            classes below create distinct subclasses for that.
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesRing_buffered {
@@ -273,9 +494,9 @@ protected:
 
 /**************************************************************************/
 /*!
-    @brief Class for Lumissil IS31FL3741 Glasses (left ring) with LED
-           data being buffered on the microcontroller and sent only when
-           show() is called.
+    @brief  Class for Lumissil IS31FL3741 Glasses (left ring) with LED
+            data being buffered on the microcontroller and sent only when
+            show() is called.
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesLeftRing_buffered
@@ -287,9 +508,9 @@ public:
 
 /**************************************************************************/
 /*!
-    @brief Class for Lumissil IS31FL3741 Glasses (right ring) with LED
-           data being buffered on the microcontroller and sent only when
-           show() is called.
+    @brief  Class for Adafruit LED Glasses (right ring) with LED data being
+            buffered on the microcontroller and sent only when show() is
+            called.
 */
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesRightRing_buffered
@@ -298,4 +519,5 @@ public:
   Adafruit_IS31FL3741_GlassesRightRing_buffered(
       Adafruit_IS31FL3741_buffered *controller);
 };
-#endif
+
+#endif // _ADAFRUIT_IS31FL3741_H_

--- a/Adafruit_IS31FL3741.h
+++ b/Adafruit_IS31FL3741.h
@@ -220,8 +220,8 @@ public:
     @brief  Constructor for Lumissil IS31FL3741 OEM evaluation board,
             13x9 pixels, direct (unbuffered).
   */
-  Adafruit_IS31FL3741_EVB(uint8_t order = IS3741_RGB)
-      : Adafruit_IS31FL3741_colorGFX(13, 9, order) {}
+  Adafruit_IS31FL3741_EVB(uint8_t order = IS3741_BGR)
+      : Adafruit_IS31FL3741_colorGFX(9, 13, order) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 };
 
@@ -237,8 +237,8 @@ public:
     @brief  Constructor for Lumissil IS31FL3741 OEM evaluation board,
             13x9 pixels, buffered.
   */
-  Adafruit_IS31FL3741_EVB_buffered(uint8_t order = IS3741_RGB)
-      : Adafruit_IS31FL3741_colorGFX_buffered(13, 9, order) {}
+  Adafruit_IS31FL3741_EVB_buffered(uint8_t order = IS3741_BGR)
+      : Adafruit_IS31FL3741_colorGFX_buffered(9, 13, order) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 };
 

--- a/Adafruit_IS31FL3741.h
+++ b/Adafruit_IS31FL3741.h
@@ -145,7 +145,7 @@ public:
       : rOffset((order >> 4) & 3), gOffset((order >> 2) & 3),
         bOffset(order & 3) {}
 
-//protected:
+protected:
   uint8_t rOffset;
   uint8_t gOffset;
   uint8_t bOffset;
@@ -266,6 +266,11 @@ public:
 /*!
     @brief  Base class for EyeLights LED ring. Holds a few items that are
             common to direct or buffered instances, left or right ring.
+    @note   This inherits from ColorOrder because the ring color-setting
+            functions require R/G/B order knowledge, but that information
+            is over in a sibling class...so, a duplicate copy resides here,
+            initialized alongside the sibling. Maybe that's kludgey, but
+            eh, it's 3 bytes, even a pointer-to-other-object is bigger.
 */
 /**************************************************************************/
 class Adafruit_EyeLights_Ring_Base : public Adafruit_IS31FL3741_ColorOrder {
@@ -284,6 +289,7 @@ public:
     @param  b  Brightness from 0 (off) to 255 (max).
   */
   void setBrightness(uint8_t b) { _brightness = b + 1; }
+
 protected:
   uint16_t _brightness = 256; ///< Internally 1-256 for math
   const uint16_t *ring_map;   ///< Pointer to lookup table
@@ -296,7 +302,8 @@ protected:
 /**************************************************************************/
 class Adafruit_EyeLights_Ring : public Adafruit_EyeLights_Ring_Base {
 public:
-  Adafruit_EyeLights_Ring(bool isRight, uint8_t order) : Adafruit_EyeLights_Ring_Base(isRight, order) {}
+  Adafruit_EyeLights_Ring(bool isRight, uint8_t order)
+      : Adafruit_EyeLights_Ring_Base(isRight, order) {}
   void setPixelColor(int16_t n, uint32_t color);
   void fill(uint32_t color);
 };
@@ -308,7 +315,8 @@ public:
 /**************************************************************************/
 class Adafruit_EyeLights_Ring_buffered : public Adafruit_EyeLights_Ring_Base {
 public:
-  Adafruit_EyeLights_Ring_buffered(bool isRight, uint8_t order) : Adafruit_EyeLights_Ring_Base(isRight, order) {}
+  Adafruit_EyeLights_Ring_buffered(bool isRight, uint8_t order)
+      : Adafruit_EyeLights_Ring_Base(isRight, order) {}
   void setPixelColor(int16_t n, uint32_t color);
   void fill(uint32_t color);
 };
@@ -328,6 +336,7 @@ public:
     @returns  GFXcanvas16*  Pointer to GFXcanvas16 object, or NULL.
   */
   GFXcanvas16 *getCanvas(void) const { return canvas; };
+
 protected:
   GFXcanvas16 *canvas = NULL; ///< Pointer to GFX canvas
 };
@@ -337,12 +346,14 @@ protected:
     @brief  Class for Adafruit EyeLights, direct (unbuffered).
 */
 /**************************************************************************/
-class Adafruit_EyeLights : public Adafruit_EyeLights_Base, public Adafruit_IS31FL3741_colorGFX {
+class Adafruit_EyeLights : public Adafruit_EyeLights_Base,
+                           public Adafruit_IS31FL3741_colorGFX {
 public:
   Adafruit_EyeLights(bool withCanvas = false, uint8_t order = IS3741_RGB);
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   Adafruit_EyeLights_Ring left_ring;
   Adafruit_EyeLights_Ring right_ring;
+
 protected:
 };
 
@@ -351,18 +362,21 @@ protected:
     @brief  Class for Adafruit EyeLights, buffered.
 */
 /**************************************************************************/
-class Adafruit_EyeLights_buffered : public Adafruit_EyeLights_Base, public Adafruit_IS31FL3741_colorGFX_buffered {
+class Adafruit_EyeLights_buffered
+    : public Adafruit_EyeLights_Base,
+      public Adafruit_IS31FL3741_colorGFX_buffered {
 public:
-  Adafruit_EyeLights_buffered(bool withCanvas = false, uint8_t order = IS3741_RGB);
+  Adafruit_EyeLights_buffered(bool withCanvas = false,
+                              uint8_t order = IS3741_RGB);
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   Adafruit_EyeLights_Ring_buffered left_ring;
   Adafruit_EyeLights_Ring_buffered right_ring;
 };
 
-
 /* =======================================================================
    This is the older and maybe deprecated way of using Adafruit EyeLights.
-   It requires a few extra steps of the user for object declarations.
+   It requires a few extra steps of the user for object declarations, and
+   doesn't handle different RGB color orders.
    =======================================================================*/
 
 /**************************************************************************/

--- a/Adafruit_IS31FL3741.h
+++ b/Adafruit_IS31FL3741.h
@@ -27,6 +27,8 @@
 #define IS3741_BRG ((1 << 4) | (2 << 2) | (0)) ///< Encode as B,R,G
 #define IS3741_BGR ((2 << 4) | (1 << 2) | (0)) ///< Encode as B,G,R
 
+// BASE IS31 CLASSES -------------------------------------------------------
+
 /**************************************************************************/
 /*!
     @brief  Class for Lumissil IS31FL3741 LED driver. This is the base class
@@ -61,7 +63,7 @@ public:
   // its subclasses do. These color-related operations go here so that all
   // subclasses have access. Any 'packed' 24-bit colors received or returned
   // by these functions are always in 0xRRGGBB order; RGB reordering for
-  // different devices takes place elsewhere, in subclasses.
+  // specific devices takes place elsewhere, in subclasses.
 
   /*!
     @brief    Converter for RGB888-format color (separate) to RGB565-format
@@ -125,6 +127,8 @@ public:
 protected:
   uint8_t ledbuf[352]; ///< LEDs in RAM. +1 byte is intentional, see show()
 };
+
+// INTERMEDIARY CLASSES FOR COLORS AND GFX ---------------------------------
 
 /**************************************************************************/
 /*!
@@ -212,7 +216,12 @@ public:
 /**************************************************************************/
 class Adafruit_IS31FL3741_EVB : public Adafruit_IS31FL3741_colorGFX {
 public:
-  Adafruit_IS31FL3741_EVB(uint8_t order = IS3741_RGB);
+  /*!
+    @brief  Constructor for Lumissil IS31FL3741 OEM evaluation board,
+            13x9 pixels, direct (unbuffered).
+  */
+  Adafruit_IS31FL3741_EVB(uint8_t order = IS3741_RGB)
+      : Adafruit_IS31FL3741_colorGFX(13, 9, order) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 };
 
@@ -224,7 +233,12 @@ public:
 class Adafruit_IS31FL3741_EVB_buffered
     : public Adafruit_IS31FL3741_colorGFX_buffered {
 public:
-  Adafruit_IS31FL3741_EVB_buffered(uint8_t order = IS3741_RGB);
+  /*!
+    @brief  Constructor for Lumissil IS31FL3741 OEM evaluation board,
+            13x9 pixels, buffered.
+  */
+  Adafruit_IS31FL3741_EVB_buffered(uint8_t order = IS3741_RGB)
+      : Adafruit_IS31FL3741_colorGFX_buffered(13, 9, order) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 };
 
@@ -236,7 +250,12 @@ public:
 /**************************************************************************/
 class Adafruit_IS31FL3741_QT : public Adafruit_IS31FL3741_colorGFX {
 public:
-  Adafruit_IS31FL3741_QT(uint8_t order = IS3741_RGB);
+  /*!
+    @brief  Constructor for STEMMA QT version (13 x 9 LEDs), direct
+            (unbuffered).
+  */
+  Adafruit_IS31FL3741_QT(uint8_t order = IS3741_RGB)
+      : Adafruit_IS31FL3741_colorGFX(13, 9, order) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 };
 
@@ -248,7 +267,11 @@ public:
 class Adafruit_IS31FL3741_QT_buffered
     : public Adafruit_IS31FL3741_colorGFX_buffered {
 public:
-  Adafruit_IS31FL3741_QT_buffered(uint8_t order = IS3741_RGB);
+  /*!
+    @brief  Constructor for STEMMA QT version (13 x 9 LEDs), buffered.
+  */
+  Adafruit_IS31FL3741_QT_buffered(uint8_t order = IS3741_RGB)
+      : Adafruit_IS31FL3741_colorGFX_buffered(13, 9, order) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 };
 
@@ -334,6 +357,7 @@ public:
     @returns  GFXcanvas16*  Pointer to GFXcanvas16 object, or NULL.
   */
   GFXcanvas16 *getCanvas(void) const { return canvas; }
+
 protected:
   GFXcanvas16 *canvas = NULL; ///< Pointer to GFX canvas
 };
@@ -391,7 +415,12 @@ public:
 /**************************************************************************/
 class Adafruit_IS31FL3741_GlassesMatrix : public Adafruit_GFX {
 public:
-  Adafruit_IS31FL3741_GlassesMatrix(Adafruit_IS31FL3741 *controller);
+  /*!
+    @brief  Constructor for LED glasses (matrix portion, 18x5 LEDs)
+    @param  controller  Pointer to core object (underlying hardware).
+  */
+  Adafruit_IS31FL3741_GlassesMatrix(Adafruit_IS31FL3741 *controller)
+      : Adafruit_GFX(18, 5), _is31(controller) {}
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 
 protected:
@@ -443,7 +472,12 @@ protected:
 class Adafruit_IS31FL3741_GlassesLeftRing
     : public Adafruit_IS31FL3741_GlassesRing {
 public:
-  Adafruit_IS31FL3741_GlassesLeftRing(Adafruit_IS31FL3741 *controller);
+  /*!
+    @brief  Constructor for glasses left LED ring.
+    @param  controller  Pointer to Adafruit_IS31FL3741 object.
+  */
+  Adafruit_IS31FL3741_GlassesLeftRing(Adafruit_IS31FL3741 *controller)
+      : Adafruit_IS31FL3741_GlassesRing(controller, false) {}
 };
 
 /**************************************************************************/
@@ -456,7 +490,12 @@ public:
 class Adafruit_IS31FL3741_GlassesRightRing
     : public Adafruit_IS31FL3741_GlassesRing {
 public:
-  Adafruit_IS31FL3741_GlassesRightRing(Adafruit_IS31FL3741 *controller);
+  /*!
+    @brief  Constructor for glasses right LED ring.
+    @param  controller  Pointer to Adafruit_IS31FL3741 object.
+  */
+  Adafruit_IS31FL3741_GlassesRightRing(Adafruit_IS31FL3741 *controller)
+      : Adafruit_IS31FL3741_GlassesRing(controller, true) {}
 };
 
 /**************************************************************************/
@@ -533,8 +572,13 @@ protected:
 class Adafruit_IS31FL3741_GlassesLeftRing_buffered
     : public Adafruit_IS31FL3741_GlassesRing_buffered {
 public:
+  /*!
+    @brief  Constructor for buffered glasses left LED ring.
+    @param  controller  Pointer to Adafruit_IS31FL3741_buffered object.
+  */
   Adafruit_IS31FL3741_GlassesLeftRing_buffered(
-      Adafruit_IS31FL3741_buffered *controller);
+      Adafruit_IS31FL3741_buffered *controller)
+      : Adafruit_IS31FL3741_GlassesRing_buffered(controller, false) {}
 };
 
 /**************************************************************************/
@@ -549,8 +593,13 @@ public:
 class Adafruit_IS31FL3741_GlassesRightRing_buffered
     : public Adafruit_IS31FL3741_GlassesRing_buffered {
 public:
+  /*!
+    @brief  Constructor for buffered glasses right LED ring.
+    @param  controller  Pointer to Adafruit_IS31FL3741_buffered object.
+  */
   Adafruit_IS31FL3741_GlassesRightRing_buffered(
-      Adafruit_IS31FL3741_buffered *controller);
+      Adafruit_IS31FL3741_buffered *controller)
+      : Adafruit_IS31FL3741_GlassesRing_buffered(controller, true) {}
 };
 
 #endif // _ADAFRUIT_IS31FL3741_H_

--- a/Adafruit_IS31FL3741.h
+++ b/Adafruit_IS31FL3741.h
@@ -61,6 +61,16 @@ public:
   bool setLEDPWM(uint16_t lednum, uint8_t pwm);
   bool fill(uint8_t fillpwm = 0);
 
+  /*!
+    @brief  Empty function makes direct & buffered code more interchangeable.
+            Direct classes have an immediate effect when setting LED states,
+            only buffered ones need an explicit call to show(), but it gets
+            annoying when moving code back and forth. So this does nothing
+            in the direct case. For code that you KNOW will always be
+            strictly unbuffered, don't call this, it sets a bad precedent.
+  */
+  inline const void show(void) {}
+
   // Although Adafruit_IS31FL3741 itself has no concept of color, most of
   // its subclasses do. These color-related operations go here so that all
   // subclasses have access. Any 'packed' 24-bit colors received or returned

--- a/Adafruit_IS31FL3741.h
+++ b/Adafruit_IS31FL3741.h
@@ -370,7 +370,7 @@ protected:
 class Adafruit_EyeLights : public Adafruit_EyeLights_Base,
                            public Adafruit_IS31FL3741_colorGFX {
 public:
-  Adafruit_EyeLights(bool withCanvas = false, uint8_t order = IS3741_RGB)
+  Adafruit_EyeLights(bool withCanvas = false, uint8_t order = IS3741_BGR)
       : Adafruit_EyeLights_Base(withCanvas),
         Adafruit_IS31FL3741_colorGFX(18, 5, order), left_ring(this, false),
         right_ring(this, true) {}
@@ -390,7 +390,7 @@ class Adafruit_EyeLights_buffered
       public Adafruit_IS31FL3741_colorGFX_buffered {
 public:
   Adafruit_EyeLights_buffered(bool withCanvas = false,
-                              uint8_t order = IS3741_RGB)
+                              uint8_t order = IS3741_BGR)
       : Adafruit_EyeLights_Base(withCanvas),
         Adafruit_IS31FL3741_colorGFX_buffered(18, 5, order),
         left_ring(this, false), right_ring(this, true) {}

--- a/Adafruit_IS31FL3741.h
+++ b/Adafruit_IS31FL3741.h
@@ -69,7 +69,7 @@ public:
             in the direct case. For code that you KNOW will always be
             strictly unbuffered, don't call this, it sets a bad precedent.
   */
-  inline const void show(void) {}
+  inline void show(void) {}
 
   // Although Adafruit_IS31FL3741 itself has no concept of color, most of
   // its subclasses do. These color-related operations go here so that all
@@ -364,7 +364,6 @@ public:
     if (withCanvas)
       canvas = new GFXcanvas16(18 * 3, 5 * 3);
   }
-  ~Adafruit_EyeLights_Base() { delete canvas; }
   /*!
     @brief    Get pointer to GFX canvas for smooth drawing.
     @returns  GFXcanvas16*  Pointer to GFXcanvas16 object, or NULL.

--- a/examples/glassesdemo-1-direct/glassesdemo-1-direct.ino
+++ b/examples/glassesdemo-1-direct/glassesdemo-1-direct.ino
@@ -10,7 +10,7 @@
 // Some boards have just one I2C interface, but some have more...
 TwoWire *i2c = &Wire; // e.g. change this to &Wire1 for QT Py RP2040
 
-// Eyelights glasses object in simplest form
+// EyeLights glasses object in simplest form
 Adafruit_EyeLights glasses;
 
 char text[] = "ADAFRUIT!";    // A message to scroll

--- a/examples/glassesdemo-2-buffered/glassesdemo-2-buffered.ino
+++ b/examples/glassesdemo-2-buffered/glassesdemo-2-buffered.ino
@@ -11,29 +11,21 @@
 // Some boards have just one I2C interface, but some have more...
 TwoWire *i2c = &Wire; // e.g. change this to &Wire1 for QT Py RP2040
 
-// Notice the object declarations here are just slightly different --
-// each has "_buffered" appended to the object type.
+// Notice the glasses object declaration here is just slightly different --
+// with "_buffered" appended to the object type.
+Adafruit_EyeLights_buffered glasses;
 
-// This is the glasses' core LED controller object
-Adafruit_IS31FL3741_buffered ledcontroller;
-
-// And these objects relate to the glasses' matrix and rings.
-// Each expects the address of the controller object.
-Adafruit_IS31FL3741_GlassesMatrix_buffered    ledmatrix(&ledcontroller);
-Adafruit_IS31FL3741_GlassesLeftRing_buffered  leftring(&ledcontroller);
-Adafruit_IS31FL3741_GlassesRightRing_buffered rightring(&ledcontroller);
-
-char text[] = "ADAFRUIT!";      // A message to scroll
-int text_x = ledmatrix.width(); // Initial text position = off right edge
-int text_min;                   // Pos. where text resets (calc'd later)
-int text_y = 5;                 // Text base line at bottom of matrix
-uint16_t ring_hue = 0;          // For ring animation
+char text[] = "ADAFRUIT!";    // A message to scroll
+int text_x = glasses.width(); // Initial text position = off right edge
+int text_min;                 // Pos. where text resets (calc'd later)
+int text_y = 5;               // Text base line at bottom of matrix
+uint16_t ring_hue = 0;        // For ring animation
 
 void setup() {
   Serial.begin(115200);
   Serial.println("ISSI3741 LED Glasses Adafruit GFX Test");
 
-  if (! ledcontroller.begin(IS3741_ADDR_DEFAULT, i2c)) {
+  if (! glasses.begin(IS3741_ADDR_DEFAULT, i2c)) {
     Serial.println("IS41 not found");
     for (;;);
   }
@@ -45,46 +37,46 @@ void setup() {
   i2c->setClock(800000);
 
   // Set brightness to max and bring controller out of shutdown state
-  ledcontroller.setLEDscaling(0xFF);
-  ledcontroller.setGlobalCurrent(0xFF);
-  ledcontroller.enable(true);
+  glasses.setLEDscaling(0xFF);
+  glasses.setGlobalCurrent(0xFF);
+  glasses.enable(true);
 
   // Clear all LEDs, set to normal upright orientation
-  ledmatrix.fillScreen(0);
-  ledmatrix.setRotation(0);
+  glasses.fillScreen(0);
+  glasses.setRotation(0);
 
-  ledmatrix.setFont(&TomThumb); // Tom Thumb 3x5 font, ideal for small matrix
-  ledmatrix.setTextWrap(false); // Allow text to extend off edges
+  glasses.setFont(&TomThumb); // Tom Thumb 3x5 font, ideal for small matrix
+  glasses.setTextWrap(false); // Allow text to extend off edges
 
-  rightring.setBrightness(50);  // Turn down the LED rings brightness,
-  leftring.setBrightness(50);   // 0 = off, 255 = max
+  glasses.right_ring.setBrightness(50);  // Turn down the LED rings brightness,
+  glasses.left_ring.setBrightness(50);   // 0 = off, 255 = max
 
   // Get text dimensions to determine X coord where scrolling resets
   uint16_t w, h;
   int16_t ignore;
-  ledmatrix.getTextBounds(text, 0, 0, &ignore, &ignore, &w, &h);
+  glasses.getTextBounds(text, 0, 0, &ignore, &ignore, &w, &h);
   text_min = -w; // Off left edge this many pixels
 }
 
 void loop() {
   // Unlike the prior example, no need to explicitly erase just the text
   // pixels. Can clear the whole matrix with one call...
-  ledmatrix.fillScreen(0);
+  glasses.fillScreen(0);
   // The rest of this function is nearly the same as before, except for
   // the required show() call near the end.
 
   // Update text to new position, and draw
   if (--text_x < text_min) {    // If text scrolls off left edge,
-    text_x = ledmatrix.width(); // reset position off right edge
+    text_x = glasses.width(); // reset position off right edge
   }
-  ledmatrix.setCursor(text_x, text_y);
+  glasses.setCursor(text_x, text_y);
   for (int i = 0; i < (int)strlen(text); i++) {
     // Get 24-bit color for this character, cycling through color wheel
-    uint32_t color888 = ledcontroller.ColorHSV(65536 * i / strlen(text));
+    uint32_t color888 = glasses.ColorHSV(65536 * i / strlen(text));
     // Remap 24-bit color to '565' color used by Adafruit_GFX
-    uint16_t color565 = ledcontroller.color565(color888);
-    ledmatrix.setTextColor(color565); // Set text color
-    ledmatrix.print(text[i]);         // and print one character
+    uint16_t color565 = glasses.color565(color888);
+    glasses.setTextColor(color565); // Set text color
+    glasses.print(text[i]);         // and print one character
   }
 
   // The matrix and rings share some pixels in common. Drawing the
@@ -95,19 +87,19 @@ void loop() {
   // Animate the LED rings with a color wheel. Unlike the matrix (which uses
   // GFX library's "565" color, the rings use NeoPixel-style RGB colors
   // (three 8-bit values, or one 24-bit value as returned here by ColorHSV()).
-  for (int i=0; i < leftring.numPixels(); i++) {
-    leftring.setPixelColor(i, ledcontroller.ColorHSV(
-      ring_hue + i * 65536 / leftring.numPixels()));
+  for (int i=0; i < glasses.left_ring.numPixels(); i++) {
+    glasses.left_ring.setPixelColor(i, glasses.ColorHSV(
+      ring_hue + i * 65536 / glasses.left_ring.numPixels()));
   }
-  for (int i=0; i < rightring.numPixels(); i++) {
-    rightring.setPixelColor(i, ledcontroller.ColorHSV(
-      ring_hue - i * 65536 / rightring.numPixels()));
+  for (int i=0; i < glasses.right_ring.numPixels(); i++) {
+    glasses.right_ring.setPixelColor(i, glasses.ColorHSV(
+      ring_hue - i * 65536 / glasses.right_ring.numPixels()));
   }
   ring_hue += 2000; // Shift color a bit on next frame - makes it spin
 
   // With a buffered controller, LEDs are not updated until the show()
   // function is called. You MUST do this each time you want a refresh!
-  ledcontroller.show();
+  glasses.show();
 
   delay(75); // Pause briefly to limit scrolling speed.
 }

--- a/examples/glassesdemo-3-smooth/glassesdemo-3-smooth.ino
+++ b/examples/glassesdemo-3-smooth/glassesdemo-3-smooth.ino
@@ -118,6 +118,5 @@ void loop() {
 
   glasses.show(); // Always show() with a buffered controller!
 
-  // There's no delay() in this example, we just let it run full-tilt
-  // because the drawing and scaling takes a bit longer.
+  delay(20); // Pause briefly to limit scrolling speed.
 }

--- a/examples/glassesdemo-3-smooth/glassesdemo-3-smooth.ino
+++ b/examples/glassesdemo-3-smooth/glassesdemo-3-smooth.ino
@@ -9,23 +9,16 @@
 // Some boards have just one I2C interface, but some have more...
 TwoWire *i2c = &Wire; // e.g. change this to &Wire1 for QT Py RP2040
 
-// Object declarations are nearly the same as before, with the "_buffered"
-// postfix, but notice the matrix item has an extra "true" argument now.
+// Glasses object declaration is nearly the same as before, with the
+// "_buffered" postfix, but notice it now has an extra "true" argument.
 // This creates an offscreen drawing surface that's 3X larger than the
 // matrix, and later we can shrink it down with antialiasing.
 
-// This is the glasses' core LED controller object
-Adafruit_IS31FL3741_buffered ledcontroller;
-
-// And these objects relate to the glasses' matrix and rings.
-// Each expects the address of the controller object.
-Adafruit_IS31FL3741_GlassesMatrix_buffered    ledmatrix(&ledcontroller, true);
-Adafruit_IS31FL3741_GlassesLeftRing_buffered  leftring(&ledcontroller);
-Adafruit_IS31FL3741_GlassesRightRing_buffered rightring(&ledcontroller);
+Adafruit_EyeLights_buffered glasses(true);
 
 // Notice the slight change here to the text positioning. The initial X
 // position isn't known until we're in setup() and can access the offscreen
-// canvas. Also, the Y position is now 14 instead of 5 (because 3X larger).
+// canvas. Also, the Y position is now 14 instead of 5 (because larger).
 
 char text[] = "ADAFRUIT!";      // A message to scroll
 int text_x;                     // Pos is initialized in setup()
@@ -39,12 +32,12 @@ void setup() {
   Serial.begin(115200);
   Serial.println("ISSI3741 LED Glasses Adafruit GFX Test");
 
-  if (! ledcontroller.begin(IS3741_ADDR_DEFAULT, i2c)) {
+  if (! glasses.begin(IS3741_ADDR_DEFAULT, i2c)) {
     Serial.println("IS41 not found");
     for (;;);
   }
 
-  canvas = ledmatrix.getCanvas();
+  canvas = glasses.getCanvas();
   if (! canvas) {
     Serial.println("Couldn't allocate canvas");
     for (;;);
@@ -57,9 +50,9 @@ void setup() {
   i2c->setClock(800000);
 
   // Set brightness to max and bring controller out of shutdown state
-  ledcontroller.setLEDscaling(0xFF);
-  ledcontroller.setGlobalCurrent(0xFF);
-  ledcontroller.enable(true);
+  glasses.setLEDscaling(0xFF);
+  glasses.setGlobalCurrent(0xFF);
+  glasses.enable(true);
 
   // Because canvas is a pointer to an object, not an object itself,
   // functions are accessed with -> instead of .
@@ -67,7 +60,7 @@ void setup() {
 
   // Clear canvas, set matrix to normal upright orientation
   canvas->fillScreen(0);
-  ledmatrix.setRotation(0);
+  glasses.setRotation(0);
 
   // We're using a different font, because Tom Thumb is too tiny for this.
   // Legibility isn't great with this other font, but it's what we had on
@@ -77,8 +70,8 @@ void setup() {
   canvas->setTextWrap(false); // Allow text to extend off edges
 
   // Rings work just as before
-  rightring.setBrightness(50);  // Turn down the LED rings brightness,
-  leftring.setBrightness(50);   // 0 = off, 255 = max
+  glasses.right_ring.setBrightness(50);  // Turn down the LED rings brightness,
+  glasses.left_ring.setBrightness(50);   // 0 = off, 255 = max
 
   // Get text dimensions to determine X coord where scrolling resets
   uint16_t w, h;
@@ -97,9 +90,9 @@ void loop() {
   canvas->setCursor(text_x, text_y);
   for (int i = 0; i < (int)strlen(text); i++) {
     // Get 24-bit color for this character, cycling through color wheel
-    uint32_t color888 = ledcontroller.ColorHSV(65536 * i / strlen(text));
+    uint32_t color888 = glasses.ColorHSV(65536 * i / strlen(text));
     // Remap 24-bit color to '565' color used by Adafruit_GFX
-    uint16_t color565 = ledcontroller.color565(color888);
+    uint16_t color565 = glasses.color565(color888);
     canvas->setTextColor(color565); // Set text color
     canvas->print(text[i]);         // and print one character
   }
@@ -110,20 +103,20 @@ void loop() {
   // the prior examples where the rings could be drawn behind the text,
   // that's not an option here. Black pixels in the canvas will be black
   // on the LED matrix.
-  ledmatrix.scale();
+  glasses.scale();
 
   // Animate the LED rings with a color wheel.
-  for (int i=0; i < leftring.numPixels(); i++) {
-    leftring.setPixelColor(i, ledcontroller.ColorHSV(
-      ring_hue + i * 65536 / leftring.numPixels()));
+  for (int i=0; i < glasses.left_ring.numPixels(); i++) {
+    glasses.left_ring.setPixelColor(i, glasses.ColorHSV(
+      ring_hue + i * 65536 / glasses.left_ring.numPixels()));
   }
-  for (int i=0; i < rightring.numPixels(); i++) {
-    rightring.setPixelColor(i, ledcontroller.ColorHSV(
-      ring_hue - i * 65536 / rightring.numPixels()));
+  for (int i=0; i < glasses.right_ring.numPixels(); i++) {
+    glasses.right_ring.setPixelColor(i, glasses.ColorHSV(
+      ring_hue - i * 65536 / glasses.right_ring.numPixels()));
   }
   ring_hue += 1000; // Shift color a bit on next frame - makes it spin
 
-  ledcontroller.show(); // Always show() with a buffered controller!
+  glasses.show(); // Always show() with a buffered controller!
 
   // There's no delay() in this example, we just let it run full-tilt
   // because the drawing and scaling takes a bit longer.

--- a/examples/issi-rgbswirl/issi-rgbswirl.ino
+++ b/examples/issi-rgbswirl/issi-rgbswirl.ino
@@ -3,7 +3,7 @@
 
 #include <Adafruit_IS31FL3741.h>
 
-Adafruit_IS31FL3741 ledmatrix;
+Adafruit_IS31FL3741_EVB ledmatrix;
 
 void setup() {
   Serial.begin(115200);
@@ -13,27 +13,30 @@ void setup() {
     Serial.println("IS41 not found");
     while (1);
   }
-  
+
   Serial.println("IS41 found!");
+
   ledmatrix.setLEDscaling(0xFF);
- 
   ledmatrix.setGlobalCurrent(0xFF);
   Serial.print("Global current set to: ");
   Serial.println(ledmatrix.getGlobalCurrent());
-  
   ledmatrix.enable(true); // bring out of shutdown
 }
 
 uint16_t hue_offset = 0;
 
 void loop() {
-  for (int i=0; i<351; i+=3) {
-    uint32_t color = ledmatrix.ColorHSV(i * 65536 / 351 + hue_offset);
-    ledmatrix.setLEDPWM(i+2, color>>16);
-    ledmatrix.setLEDPWM(i+1, color>>8);
-    ledmatrix.setLEDPWM(i, color);
+  uint32_t i = 0;
+  for (int y=0; y<ledmatrix.height(); y++) {
+    for (int x=0; x<ledmatrix.width(); x++) {
+      uint32_t color888 = ledmatrix.ColorHSV(i * 65536 / 117 + hue_offset);
+      uint16_t color565 = ledmatrix.color565(color888);
+      ledmatrix.drawPixel(x, y, color565);
+      i++;
+    }
   }
+
   hue_offset += 256;
-  
+
   ledmatrix.setGlobalCurrent(hue_offset / 256); // have display dim up and down
 }

--- a/examples/qtmatrix-rgbswirl-buffered/qtmatrix-rgbswirl-buffered.ino
+++ b/examples/qtmatrix-rgbswirl-buffered/qtmatrix-rgbswirl-buffered.ino
@@ -40,8 +40,8 @@ uint16_t hue_offset = 0;
 
 void loop() {
   uint32_t i = 0;
-  for (int y=0; y<9; y++) {
-    for (int x=0; x<13; x++) {
+  for (int y=0; y<ledmatrix.height(); y++) {
+    for (int x=0; x<ledmatrix.width(); x++) {
       uint32_t color888 = ledmatrix.ColorHSV(i * 65536 / 117 + hue_offset);
       uint16_t color565 = ledmatrix.color565(color888);
       ledmatrix.drawPixel(x, y, color565);

--- a/examples/qtmatrix-rgbswirl-buffered/qtmatrix-rgbswirl-buffered.ino
+++ b/examples/qtmatrix-rgbswirl-buffered/qtmatrix-rgbswirl-buffered.ino
@@ -9,6 +9,8 @@
 #include <Adafruit_IS31FL3741.h>
 
 Adafruit_IS31FL3741_QT_buffered ledmatrix;
+// If colors appear wrong on matrix, try invoking constructor like so:
+// Adafruit_IS31FL3741_QT_buffered ledmatrix(IS3741_RBG);
 
 // Some boards have just one I2C interface, but some have more...
 TwoWire *i2c = &Wire; // e.g. change this to &Wire1 for QT Py RP2040

--- a/examples/qtmatrix-rgbswirl-buffered/qtmatrix-rgbswirl-buffered.ino
+++ b/examples/qtmatrix-rgbswirl-buffered/qtmatrix-rgbswirl-buffered.ino
@@ -21,7 +21,7 @@ void setup() {
     Serial.println("IS41 not found");
     while (1);
   }
-  
+
   Serial.println("IS41 found!");
 
   // By default the LED controller communicates over I2C at 400 KHz.

--- a/examples/qtmatrix-rgbswirl/qtmatrix-rgbswirl.ino
+++ b/examples/qtmatrix-rgbswirl/qtmatrix-rgbswirl.ino
@@ -40,8 +40,8 @@ uint16_t hue_offset = 0;
 
 void loop() {
   uint32_t i = 0;
-  for (int y=0; y<9; y++) {
-    for (int x=0; x<13; x++) {
+  for (int y=0; y<ledmatrix.height(); y++) {
+    for (int x=0; x<ledmatrix.width(); x++) {
       uint32_t color888 = ledmatrix.ColorHSV(i * 65536 / 117 + hue_offset);
       uint16_t color565 = ledmatrix.color565(color888);
       ledmatrix.drawPixel(x, y, color565);

--- a/examples/qtmatrix-rgbswirl/qtmatrix-rgbswirl.ino
+++ b/examples/qtmatrix-rgbswirl/qtmatrix-rgbswirl.ino
@@ -9,6 +9,8 @@
 #include <Adafruit_IS31FL3741.h>
 
 Adafruit_IS31FL3741_QT ledmatrix;
+// If colors appear wrong on matrix, try invoking constructor like so:
+// Adafruit_IS31FL3741_QT ledmatrix(IS3741_RBG);
 
 // Some boards have just one I2C interface, but some have more...
 TwoWire *i2c = &Wire; // e.g. change this to &Wire1 for QT Py RP2040

--- a/examples/qtmatrix-rgbswirl/qtmatrix-rgbswirl.ino
+++ b/examples/qtmatrix-rgbswirl/qtmatrix-rgbswirl.ino
@@ -21,7 +21,7 @@ void setup() {
     Serial.println("IS41 not found");
     while (1);
   }
-  
+
   Serial.println("IS41 found!");
 
   // By default the LED controller communicates over I2C at 400 KHz.

--- a/examples/qtmatrix-text-buffered/qtmatrix-text-buffered.ino
+++ b/examples/qtmatrix-text-buffered/qtmatrix-text-buffered.ino
@@ -9,6 +9,8 @@
 #include <Adafruit_IS31FL3741.h>
 
 Adafruit_IS31FL3741_QT_buffered matrix;
+// If colors appear wrong on matrix, try invoking constructor like so:
+// Adafruit_IS31FL3741_QT_buffered matrix(IS3741_RBG);
 
 // Some boards have just one I2C interface, but some have more...
 TwoWire *i2c = &Wire; // e.g. change this to &Wire1 for QT Py RP2040

--- a/examples/qtmatrix-text/qtmatrix-text.ino
+++ b/examples/qtmatrix-text/qtmatrix-text.ino
@@ -9,6 +9,8 @@
 #include <Adafruit_IS31FL3741.h>
 
 Adafruit_IS31FL3741_QT matrix;
+// If colors appear wrong on matrix, try invoking constructor like so:
+// Adafruit_IS31FL3741_QT matrix(IS3741_RBG);
 
 // Some boards have just one I2C interface, but some have more...
 TwoWire *i2c = &Wire; // e.g. change this to &Wire1 for QT Py RP2040


### PR DESCRIPTION
- **Main Thing:** ISSI eval board, QT matrix and glasses all now accept an optional **color order** argument in the constructor. At present this only benefits the QT matrix, where two different versions were produced, but the idea really is to future-proof all of these devices against future LED supply changes. QT matrix examples show how to use this.
- **Less Main Thing:** Simpler API for LED glasses via a new class called **EyeLights**. Uses a single constructor, returns a single object…doesn’t require drawPixel() on one object and then show() on another, it’s all the same item. Glasses examples have been updated to use this. The old API/objects are still there for early code that might be using them, but won’t be documented in any guides, and new projects should use the new approach. The separation between old & new is pretty well demarcated in the code and header and at some point we should be able to safely delete.
- **Tertiary Thing:** numerous minor bug fixes, speed improvements, size reduction through refactoring, and better documented a few items.

If/when merged, I’ll bump the library version # and make a new release 1.2.0, because changes are not minor (but shouldn’t break existing code).